### PR TITLE
fix: reset `PluginsDiscardedPayload` reader index when getting data

### DIFF
--- a/src/main/java/com/mohistmc/youer/bukkit/messaging/PluginsDiscardedPayload.java
+++ b/src/main/java/com/mohistmc/youer/bukkit/messaging/PluginsDiscardedPayload.java
@@ -5,7 +5,6 @@ import io.netty.buffer.Unpooled;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import lombok.Getter;
 import lombok.Setter;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.resources.ResourceLocation;
@@ -15,7 +14,6 @@ public class PluginsDiscardedPayload implements PluginsPayload {
     public static final Map<ResourceLocation, Type<PluginsDiscardedPayload>> REGISTRY = new HashMap<>();
     private final Type<PluginsDiscardedPayload> type;
     @Setter
-    @Getter
     private ByteBuf data;
 
     public PluginsDiscardedPayload(Type<PluginsDiscardedPayload> type, ByteBuf raw) {
@@ -35,5 +33,11 @@ public class PluginsDiscardedPayload implements PluginsPayload {
     @Override
     public Type<PluginsDiscardedPayload> type() {
         return type;
+    }
+
+    @Override
+    public ByteBuf getData() {
+        data.resetReaderIndex();
+        return data;
     }
 }


### PR DESCRIPTION
Fixes #71 by resetting PluginsDiscardedPayload reader index when getting data. Not sure this is the best way to fix this.