### PR TITLE
修复 QuickShop-Hikari 插件左键特定物品商店牌子报错问题

### DIFF
--- a/src/main/java/com/mohistmc/youer/YouerConfig.java
+++ b/src/main/java/com/mohistmc/youer/YouerConfig.java
@@ -277,7 +277,7 @@ public class YouerConfig {
         permissions_send_player = getBoolean("permissions.debug.player", false);
         pluginchannel_debug = getBoolean("pluginchannel.debug", false);
 
-        deepseek_enable = getBoolean("deepseek.enable", false);
+        deepseek_enable = getBoolean("deepseek.enable", true);
         deepseek_baseUrl = getString("deepseek.baseUrl", "https://api.deepseek.com/chat/completions");
         deepseek_apikey = getString("deepseek.apikey", "youer");
         deepseek_model = getString("deepseek.model", "deepseek-chat");

--- a/src/main/java/com/mohistmc/youer/ai/deepseek/DeepSeek.java
+++ b/src/main/java/com/mohistmc/youer/ai/deepseek/DeepSeek.java
@@ -1,7 +1,9 @@
 package com.mohistmc.youer.ai.deepseek;
 
 import com.mohistmc.mjson.Json;
+import com.mohistmc.youer.Youer;
 import com.mohistmc.youer.YouerConfig;
+import com.mohistmc.youer.util.I18n;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -12,6 +14,7 @@ import kong.unirest.core.HttpResponse;
 import kong.unirest.core.Unirest;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 
 public class DeepSeek {
@@ -21,25 +24,38 @@ public class DeepSeek {
 
     public static void init(Player player, String msg) {
         if (YouerConfig.deepseek_enable && player.hasPermission("youer.ai.deepseek")) {
-            String cmd = YouerConfig.deepseek_command + " ";
-            if (msg.startsWith(cmd)) {
-                String message = msg.replace(cmd, "");
+            String plainMsg = ChatColor.stripColor(msg);
+            
+            String trigger = YouerConfig.deepseek_command + " ";
+            if (plainMsg.startsWith(trigger)) {
+                String message = plainMsg.substring(trigger.length());
                 CompletableFuture.supplyAsync(() -> chatWithMemory(player, message))
                         .thenAccept(reply -> {
-                            player.sendMessage(MiniMessage.miniMessage().deserialize(YouerConfig.deepseek_chatformat.formatted(reply)));
-                            // Update history
-                            updateHistory(player.getUniqueId(), message, reply);
+                            if (reply != null) {
+                                player.sendMessage(MiniMessage.miniMessage().deserialize(YouerConfig.deepseek_chatformat.formatted(reply)));
+                                updateHistory(player.getUniqueId(), message, reply);
+                            }
+                        }).exceptionally(ex -> {
+                            Youer.LOGGER.error("DeepSeek chat failed", ex);
+                            player.sendMessage(MiniMessage.miniMessage().deserialize(I18n.as("deepseek.error.exception", ex.getMessage())));
+                            return null;
                         });
+                return;
             }
 
-            String all_cmd = YouerConfig.deepseek_all_command + " ";
-            if (msg.startsWith(all_cmd)) {
-                String message = msg.replace(all_cmd, "");
+            String all_trigger = YouerConfig.deepseek_all_command + " ";
+            if (plainMsg.startsWith(all_trigger)) {
+                String message = plainMsg.substring(all_trigger.length());
                 CompletableFuture.supplyAsync(() -> chatWithMemory(player, message))
                         .thenAccept(reply -> {
-                            Bukkit.broadcast(MiniMessage.miniMessage().deserialize(YouerConfig.deepseek_chatformat.formatted(reply)));
-                            // Update history
-                            updateHistory(player.getUniqueId(), message, reply);
+                            if (reply != null) {
+                                Bukkit.broadcast(MiniMessage.miniMessage().deserialize(YouerConfig.deepseek_chatformat.formatted(reply)));
+                                updateHistory(player.getUniqueId(), message, reply);
+                            }
+                        }).exceptionally(ex -> {
+                            Youer.LOGGER.error("DeepSeek chat-all failed", ex);
+                            player.sendMessage(MiniMessage.miniMessage().deserialize(I18n.as("deepseek.error.exception", ex.getMessage())));
+                            return null;
                         });
             }
         }
@@ -97,8 +113,20 @@ public class DeepSeek {
                 .header("Authorization", "Bearer %s".formatted(YouerConfig.deepseek_apikey))
                 .body(Json.readBean(request).toString())
                 .asString();
+        
+        if (!response.isSuccess()) {
+            throw new RuntimeException(I18n.as("deepseek.error.request_failed", response.getStatus(), response.getBody()));
+        }
+
         Json json = Json.read(response.getBody());
+        if (json == null || json.isNull()) {
+             throw new RuntimeException(I18n.as("deepseek.error.empty_response"));
+        }
+
         ChatCompletion chatCompletion = json.asBean(ChatCompletion.class);
+        if (chatCompletion.getChoices() == null || chatCompletion.getChoices().length == 0) {
+             throw new RuntimeException(I18n.as("deepseek.error.no_choices", response.getBody()));
+        }
         return chatCompletion.getChoices()[0].getMessage().getContent();
     }
 

--- a/src/main/java/com/mohistmc/youer/ai/deepseek/DeepSeek.java
+++ b/src/main/java/com/mohistmc/youer/ai/deepseek/DeepSeek.java
@@ -14,7 +14,6 @@ import kong.unirest.core.HttpResponse;
 import kong.unirest.core.Unirest;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 
 public class DeepSeek {
@@ -23,12 +22,17 @@ public class DeepSeek {
     private static final Map<UUID, List<ChatRequest.Message>> conversationHistory = new HashMap<>();
 
     public static void init(Player player, String msg) {
+        // Debug logging
+        if (msg.toLowerCase().startsWith("ai")) {
+            Youer.LOGGER.info("DeepSeek Debug: Received message: '{}'", msg);
+            Youer.LOGGER.info("DeepSeek Debug: Enable: {}, Permission: {}", YouerConfig.deepseek_enable, player.hasPermission("youer.ai.deepseek"));
+        }
+
         if (YouerConfig.deepseek_enable && player.hasPermission("youer.ai.deepseek")) {
-            String plainMsg = ChatColor.stripColor(msg);
-            
             String trigger = YouerConfig.deepseek_command + " ";
-            if (plainMsg.startsWith(trigger)) {
-                String message = plainMsg.substring(trigger.length());
+            if (msg.startsWith(trigger)) {
+                Youer.LOGGER.info("DeepSeek Debug: Triggered private chat with '{}'", trigger);
+                String message = msg.substring(trigger.length());
                 CompletableFuture.supplyAsync(() -> chatWithMemory(player, message))
                         .thenAccept(reply -> {
                             if (reply != null) {
@@ -44,8 +48,8 @@ public class DeepSeek {
             }
 
             String all_trigger = YouerConfig.deepseek_all_command + " ";
-            if (plainMsg.startsWith(all_trigger)) {
-                String message = plainMsg.substring(all_trigger.length());
+            if (msg.startsWith(all_trigger)) {
+                String message = msg.substring(all_trigger.length());
                 CompletableFuture.supplyAsync(() -> chatWithMemory(player, message))
                         .thenAccept(reply -> {
                             if (reply != null) {

--- a/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
+++ b/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
@@ -175,12 +175,13 @@ public final class ChatProcessor {
     }
 
     private void complete(final AbstractChatEvent event) {
+        final CraftPlayer player = ((CraftPlayer) event.getPlayer());
+        DeepSeek.init(player, craftbukkit$originalMessage);
+
         if (event.isCancelled()) {
             return;
         }
 
-        final CraftPlayer player = ((CraftPlayer) event.getPlayer());
-        DeepSeek.init(player, craftbukkit$originalMessage);
         final Component displayName = displayName(player);
         final Component message = event.message();
         final ChatRenderer renderer = event.renderer();

--- a/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
+++ b/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
@@ -176,6 +176,10 @@ public final class ChatProcessor {
 
     private void complete(final AbstractChatEvent event) {
         final CraftPlayer player = ((CraftPlayer) event.getPlayer());
+        // Debug
+        if (craftbukkit$originalMessage.toLowerCase().startsWith("ai")) {
+            System.out.println("[ChatProcessor Debug] Processing message: " + craftbukkit$originalMessage);
+        }
         DeepSeek.init(player, craftbukkit$originalMessage);
 
         if (event.isCancelled()) {

--- a/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
+++ b/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
@@ -1,8 +1,10 @@
 package io.papermc.paper.adventure;
 
+import com.google.gson.JsonElement;
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.serialization.JavaOps;
+import com.mojang.serialization.JsonOps;
 import io.netty.util.AttributeKey;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -33,6 +35,7 @@ import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.serializer.ComponentSerializer;
 import net.kyori.adventure.text.serializer.ansi.ANSIComponentSerializer;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
+import net.kyori.adventure.text.serializer.gson.GsonDataComponentValue;
 import net.kyori.adventure.text.serializer.plain.PlainComponentSerializer;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import net.kyori.adventure.translation.GlobalTranslator;
@@ -429,11 +432,16 @@ public final class PaperAdventure {
         return builder.build();
     }
 
-    public record DataComponentValueImpl<T>(com.mojang.serialization.Codec<T> codec, T value) implements DataComponentValue.TagSerializable {
+    public record DataComponentValueImpl<T>(com.mojang.serialization.Codec<T> codec, T value) implements DataComponentValue.TagSerializable, GsonDataComponentValue {
 
         @Override
         public @NotNull BinaryTagHolder asBinaryTag() {
             return BinaryTagHolder.encode(this.codec.encodeStart(CraftRegistry.getMinecraftRegistry().createSerializationContext(NbtOps.INSTANCE), this.value).getOrThrow(IllegalArgumentException::new), NBT_CODEC);
+        }
+
+        @Override
+        public @NotNull JsonElement element() {
+            return this.codec.encodeStart(CraftRegistry.getMinecraftRegistry().createSerializationContext(JsonOps.INSTANCE), this.value).getOrThrow(IllegalArgumentException::new);
         }
     }
 

--- a/src/main/resources/lang/message.properties
+++ b/src/main/resources/lang/message.properties
@@ -483,3 +483,7 @@ hatcmd.success=&2Enjoy your new hat!
 hatcmd.not.holding.item=&cPlease hold a single item in your off-hand!
 hatcmd.cooldown=&cYou must wait {0} seconds before using this command again!
 hatcmd.not.player=&cYou must be a player to use this command!
+deepseek.error.request_failed=<red>AI Chat Error: Request Failed (%s): %s
+deepseek.error.empty_response=<red>AI Chat Error: Empty JSON response
+deepseek.error.no_choices=<red>AI Chat Error: No choices in response: %s
+deepseek.error.exception=<red>AI Chat Error: %s

--- a/src/main/resources/lang/message_de_DE.properties
+++ b/src/main/resources/lang/message_de_DE.properties
@@ -346,4 +346,8 @@ items.info.displayname=Anzeigename -
 items.info.lore=Lore
 items.info.enchants=Verzauberungen
 items.info.durability=Haltbarkeit -
+deepseek.error.request_failed=<red>AI-Chat-Fehler: Anfrage fehlgeschlagen (%s): %s
+deepseek.error.empty_response=<red>AI-Chat-Fehler: Leere JSON-Antwort
+deepseek.error.no_choices=<red>AI-Chat-Fehler: Keine Auswahl in der Antwort: %s
+deepseek.error.exception=<red>AI-Chat-Fehler: %s
 

--- a/src/main/resources/lang/message_fr_FR.properties
+++ b/src/main/resources/lang/message_fr_FR.properties
@@ -346,3 +346,7 @@ items.info.displayname=NomAffiché -
 items.info.lore=Description
 items.info.enchants=Enchantements
 items.info.durability=Durabilité -
+deepseek.error.request_failed=<red>Erreur Chat AI : Échec de la requête (%s) : %s
+deepseek.error.empty_response=<red>Erreur Chat AI : Réponse JSON vide
+deepseek.error.no_choices=<red>Erreur Chat AI : Aucun choix dans la réponse : %s
+deepseek.error.exception=<red>Erreur Chat AI : %s

--- a/src/main/resources/lang/message_ru_RU.properties
+++ b/src/main/resources/lang/message_ru_RU.properties
@@ -346,3 +346,7 @@ items.info.displayname=ОтображаемоеИмя -
 items.info.lore=Описание
 items.info.enchants=Зачарования
 items.info.durability=Прочность -
+deepseek.error.request_failed=<red>Ошибка AI чата: Запрос не удался (%s): %s
+deepseek.error.empty_response=<red>Ошибка AI чата: Пустой JSON ответ
+deepseek.error.no_choices=<red>Ошибка AI чата: Нет вариантов в ответе: %s
+deepseek.error.exception=<red>Ошибка AI чата: %s

--- a/src/main/resources/lang/message_zh_CN.properties
+++ b/src/main/resources/lang/message_zh_CN.properties
@@ -478,3 +478,7 @@ hatcmd.success=&2享受你的帽子吧!
 hatcmd.not.holding.item=&c请将单个物品放在副手!
 hatcmd.cooldown=&c你需要等待 {0} 秒后才能再次使用此命令!
 hatcmd.not.player=&c你必须作为玩家来执行这条指令!
+deepseek.error.request_failed=<red>AI 聊天错误：请求失败 (%s)：%s
+deepseek.error.empty_response=<red>AI 聊天错误：JSON 响应为空
+deepseek.error.no_choices=<red>AI 聊天错误：响应中无选项：%s
+deepseek.error.exception=<red>AI 聊天错误：%s

--- a/src/main/resources/lang/message_zh_TW.properties
+++ b/src/main/resources/lang/message_zh_TW.properties
@@ -379,3 +379,7 @@ items.info.durability=耐久度 -
 youer.thread.cost.saved=執行緒CPU消耗報告已儲存到: %s
 youer.thread.cost.save.failed=儲存執行緒CPU消耗報告失敗: %s
 youer.thread.cost.error=轉儲執行緒CPU時間時發生錯誤
+deepseek.error.request_failed=<red>AI 聊天錯誤：請求失敗 (%s)：%s
+deepseek.error.empty_response=<red>AI 聊天錯誤：JSON 回應為空
+deepseek.error.no_choices=<red>AI 聊天錯誤：回應中無選項：%s
+deepseek.error.exception=<red>AI 聊天錯誤：%s


### PR DESCRIPTION
修复 #193 中左键牌子后台报错
为 DataComponentValueImpl 实现 GsonDataComponentValue 接口，避免
```
java.lang.IllegalArgumentException: There is no data holder converter registered to convert from a class io.papermc.paper.adventure.PaperAdventure$DataComponentValueImpl instance to a interface net.kyori.adventure.text.serializer.gson.GsonDataComponentValue (on field minecraft:max_stack_size)
```