### PR TITLE
改善 DeepSeek 聊天的体验

### DIFF
--- a/src/main/java/com/mohistmc/youer/ai/deepseek/DeepSeek.java
+++ b/src/main/java/com/mohistmc/youer/ai/deepseek/DeepSeek.java
@@ -26,17 +26,24 @@ public class DeepSeek {
     @Getter
     private static final Map<UUID, List<ChatRequest.Message>> conversationHistory = new HashMap<>();
 
-    public static void init(Player player, String msg) {
+    public static boolean init(Player player, String msg) {
         if (YouerConfig.deepseek_enable && player.hasPermission("youer.ai.deepseek")) {
             String cmd = YouerConfig.deepseek_command + " ";
             String all_cmd = YouerConfig.deepseek_all_command + " ";
-            msg = ColorAPI.stripColors(msg);
-            if (msg.startsWith(cmd)) {
-                handleCommand(player, msg.substring(cmd.length()), false);
-            } else if (msg.startsWith(all_cmd)) {
-                handleCommand(player, msg.substring(all_cmd.length()), true);
+            String strippedMsg = ColorAPI.stripColors(msg);
+            if (strippedMsg.startsWith(cmd)) {
+                String chatMsg = strippedMsg.substring(cmd.length());
+                player.sendMessage("<" + player.getName() + "> " + msg);
+                handleCommand(player, chatMsg, false);
+                return true;
+            } else if (strippedMsg.startsWith(all_cmd)) {
+                String chatMsg = strippedMsg.substring(all_cmd.length());
+                Bukkit.broadcastMessage("<" + player.getName() + "> " + msg);
+                handleCommand(player, chatMsg, true);
+                return true;
             }
         }
+        return false;
     }
 
     private static void handleCommand(Player player, String message, boolean isBroadcast) {
@@ -54,7 +61,15 @@ public class DeepSeek {
                 })
                 .exceptionally(throwable -> {
                     player.sendMessage(YouerConfig.deepseek_chatformat.formatted(Youer.i18n.as("deepseek.error.throwable")));
-                    LOGGER.error("DeepSeek chat failed", throwable);
+                    Throwable cause = throwable;
+                    while (cause.getCause() != null && cause != cause.getCause()) {
+                        cause = cause.getCause();
+                    }
+                    String errorMsg = cause.getMessage();
+                    if (errorMsg == null || errorMsg.isEmpty()) {
+                        errorMsg = cause.toString();
+                    }
+                    LOGGER.error(errorMsg);
                     return null;
                 });
     }
@@ -124,7 +139,19 @@ public class DeepSeek {
                 .asString();
 
         if (!response.isSuccess()) {
-            throw new RuntimeException(I18n.as("deepseek.error.request_failed", response.getStatus(), response.getBody()));
+            String errorBody = response.getBody();
+            if (errorBody == null || errorBody.trim().isEmpty()) {
+                errorBody = "No error message returned from API";
+            } else {
+                try {
+                    Json errorJson = Json.read(errorBody);
+                    if (errorJson != null && errorJson.has("error") && errorJson.at("error").has("message")) {
+                        errorBody = errorJson.at("error").at("message").asString();
+                    }
+                } catch (Exception ignored) {
+                }
+            }
+            throw new RuntimeException(I18n.as("deepseek.error.request_failed", response.getStatus(), errorBody));
         }
         Json json = Json.read(response.getBody());
         if (json == null || json.isNull()) {

--- a/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
+++ b/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
@@ -77,7 +77,9 @@ public final class ChatProcessor {
     @SuppressWarnings("deprecated")
     public void process() {
         final CraftPlayer player = this.player.getBukkitEntity();
-        DeepSeek.init(player, craftbukkit$originalMessage);
+        if (DeepSeek.init(player, craftbukkit$originalMessage)) {
+            return;
+        }
         final boolean listenersOnAsyncEvent = canYouHearMe(AsyncPlayerChatEvent.getHandlerList());
         final boolean listenersOnSyncEvent = canYouHearMe(PlayerChatEvent.getHandlerList());
         if (listenersOnAsyncEvent || listenersOnSyncEvent) {


### PR DESCRIPTION
移除多余的英文错误前缀
修复报错冒号后无内容的问题
出错时打印最底层错误，而不是整个堆栈
修复错误信息发送在玩家消息之前的问题
修复私聊AI时发送玩家消息至公屏的问题