### PR TITLE
优化端口冲突时的错误处理

### DIFF
--- a/patches/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/net/minecraft/server/MinecraftServer.java.patch
@@ -83,7 +83,7 @@
  import net.minecraft.world.entity.ai.village.VillageSiege;
  import net.minecraft.world.entity.npc.CatSpawner;
  import net.minecraft.world.entity.npc.WanderingTraderSpawner;
-@@ -161,14 +_,41 @@
+@@ -161,14 +_,42 @@
  import net.minecraft.world.level.storage.LevelResource;
  import net.minecraft.world.level.storage.LevelStorageSource;
  import net.minecraft.world.level.storage.PlayerDataStorage;
@@ -119,6 +119,7 @@
 +import org.spigotmc.SpigotConfig;
  
  public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTask> implements ServerInfo, ChunkIOErrorReporter, CommandSource, AutoCloseable {
++    public static final String PORT_BIND_FAILED = "PORT_BIND_FAILED"; // Youer
 +    private static MinecraftServer SERVER; // Paper
      public static final Logger LOGGER = LogUtils.getLogger();
 +    public static final net.kyori.adventure.text.logger.slf4j.ComponentLogger COMPONENT_LOGGER = net.kyori.adventure.text.logger.slf4j.ComponentLogger.logger(LOGGER.getName()); // Paper
@@ -834,7 +835,7 @@
                  this.startMeasuringTaskExecutionTime();
                  this.waitUntilNextTick();
                  this.finishMeasuringTaskExecutionTime();
-@@ -710,34 +_,41 @@
+@@ -710,34 +_,44 @@
  
                  this.profiler.pop();
                  this.logFullTickTime();
@@ -850,6 +851,9 @@
 +            // Paper start
 +            if (throwable1 instanceof ThreadDeath) {
 +                MinecraftServer.LOGGER.error("Main thread terminated by WatchDog due to hard crash", throwable1);
++                return;
++            }
++            if (throwable1 instanceof IllegalStateException && PORT_BIND_FAILED.equals(throwable1.getMessage())) {
 +                return;
 +            }
 +            // Paper end

--- a/patches/net/minecraft/server/dedicated/DedicatedServer.java.patch
+++ b/patches/net/minecraft/server/dedicated/DedicatedServer.java.patch
@@ -228,10 +228,11 @@
 -            LOGGER.warn("**** FAILED TO BIND TO PORT!");
 -            LOGGER.warn("The exception was: {}", ioexception.toString());
 -            LOGGER.warn("Perhaps a server is already running on that port?");
+-            return false;
 +            LOGGER.warn(I18n.as("minecraftserver.bindport1"));
 +            LOGGER.warn(I18n.as("minecraftserver.bindport2", ioexception.getMessage()));
 +            LOGGER.warn(I18n.as("minecraftserver.bindport3",this.getPort()));
-             return false;
++            throw new IllegalStateException(MinecraftServer.PORT_BIND_FAILED); // Youer
          }
  
          if (!this.usesAuthentication()) {


### PR DESCRIPTION
在端口冲突时输出小小墨提示后不再打印堆栈或生成崩溃报告，正常退出