### PR TITLE
Add Folia scheduler stubs & parallel-build fix

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,181 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "java",
+      "request": "launch",
+      "name": "base - Client",
+      "presentation": {
+        "group": "Mod Development - base",
+        "order": 0
+      },
+      "projectName": "base",
+      "mainClass": "net.neoforged.devlaunch.Main",
+      "args": [
+        "@C:\\Users\\Dragon\\Documents\\GitHub\\Youer\\projects\\base\\build\\neodev\\clientRunProgramArgs.txt"
+      ],
+      "vmArgs": [
+        "@C:\\Users\\Dragon\\Documents\\GitHub\\Youer\\projects\\base\\build\\neodev\\clientRunVmArgs.txt",
+        "-Dfml.modFolders\u003d"
+      ],
+      "cwd": "${workspaceFolder}\\projects\\base\\run\\client",
+      "env": {},
+      "console": "internalConsole",
+      "shortenCommandLine": "none"
+    },
+    {
+      "type": "java",
+      "request": "launch",
+      "name": "base - ClientData",
+      "presentation": {
+        "group": "Mod Development - base",
+        "order": 1
+      },
+      "projectName": "base",
+      "mainClass": "net.neoforged.devlaunch.Main",
+      "args": [
+        "@C:\\Users\\Dragon\\Documents\\GitHub\\Youer\\projects\\base\\build\\neodev\\clientDataRunProgramArgs.txt"
+      ],
+      "vmArgs": [
+        "@C:\\Users\\Dragon\\Documents\\GitHub\\Youer\\projects\\base\\build\\neodev\\clientDataRunVmArgs.txt",
+        "-Dfml.modFolders\u003d"
+      ],
+      "cwd": "${workspaceFolder}\\projects\\base\\run\\clientData",
+      "env": {},
+      "console": "internalConsole",
+      "shortenCommandLine": "none"
+    },
+    {
+      "type": "java",
+      "request": "launch",
+      "name": "base - Server",
+      "presentation": {
+        "group": "Mod Development - base",
+        "order": 2
+      },
+      "projectName": "base",
+      "mainClass": "net.neoforged.devlaunch.Main",
+      "args": [
+        "@C:\\Users\\Dragon\\Documents\\GitHub\\Youer\\projects\\base\\build\\neodev\\serverRunProgramArgs.txt"
+      ],
+      "vmArgs": [
+        "@C:\\Users\\Dragon\\Documents\\GitHub\\Youer\\projects\\base\\build\\neodev\\serverRunVmArgs.txt",
+        "-Dfml.modFolders\u003d"
+      ],
+      "cwd": "${workspaceFolder}\\projects\\base\\run\\server",
+      "env": {},
+      "console": "internalConsole",
+      "shortenCommandLine": "none"
+    },
+    {
+      "type": "java",
+      "request": "launch",
+      "name": "base - ServerData",
+      "presentation": {
+        "group": "Mod Development - base",
+        "order": 3
+      },
+      "projectName": "base",
+      "mainClass": "net.neoforged.devlaunch.Main",
+      "args": [
+        "@C:\\Users\\Dragon\\Documents\\GitHub\\Youer\\projects\\base\\build\\neodev\\serverDataRunProgramArgs.txt"
+      ],
+      "vmArgs": [
+        "@C:\\Users\\Dragon\\Documents\\GitHub\\Youer\\projects\\base\\build\\neodev\\serverDataRunVmArgs.txt",
+        "-Dfml.modFolders\u003d"
+      ],
+      "cwd": "${workspaceFolder}\\projects\\base\\run\\serverData",
+      "env": {},
+      "console": "internalConsole",
+      "shortenCommandLine": "none"
+    },
+    {
+      "type": "java",
+      "request": "launch",
+      "name": "neoforge - Client",
+      "presentation": {
+        "group": "Mod Development - neoforge",
+        "order": 0
+      },
+      "projectName": "neoforge",
+      "mainClass": "net.neoforged.devlaunch.Main",
+      "args": [
+        "@C:\\Users\\Dragon\\Documents\\GitHub\\Youer\\projects\\youer\\build\\neodev\\clientRunProgramArgs.txt"
+      ],
+      "vmArgs": [
+        "@C:\\Users\\Dragon\\Documents\\GitHub\\Youer\\projects\\youer\\build\\neodev\\clientRunVmArgs.txt",
+        "-Dfml.modFolders\u003dminecraft%%C:\\Users\\Dragon\\Documents\\GitHub\\Youer\\projects\\youer\\bin\\main;minecraft%%C:\\Users\\Dragon\\Documents\\GitHub\\Youer\\projects\\youer\\bin\\client;neoforge-coremods%%C:\\Users\\Dragon\\Documents\\GitHub\\Youer\\coremods\\bin\\main"
+      ],
+      "cwd": "${workspaceFolder}\\projects\\youer\\run\\client",
+      "env": {},
+      "console": "internalConsole",
+      "shortenCommandLine": "none"
+    },
+    {
+      "type": "java",
+      "request": "launch",
+      "name": "neoforge - Data",
+      "presentation": {
+        "group": "Mod Development - neoforge",
+        "order": 1
+      },
+      "projectName": "neoforge",
+      "mainClass": "net.neoforged.devlaunch.Main",
+      "args": [
+        "@C:\\Users\\Dragon\\Documents\\GitHub\\Youer\\projects\\youer\\build\\neodev\\dataRunProgramArgs.txt"
+      ],
+      "vmArgs": [
+        "@C:\\Users\\Dragon\\Documents\\GitHub\\Youer\\projects\\youer\\build\\neodev\\dataRunVmArgs.txt",
+        "-Dfml.modFolders\u003dminecraft%%C:\\Users\\Dragon\\Documents\\GitHub\\Youer\\projects\\youer\\bin\\main;minecraft%%C:\\Users\\Dragon\\Documents\\GitHub\\Youer\\projects\\youer\\bin\\client;neoforge-coremods%%C:\\Users\\Dragon\\Documents\\GitHub\\Youer\\coremods\\bin\\main"
+      ],
+      "cwd": "${workspaceFolder}\\projects\\youer\\run\\data",
+      "env": {},
+      "console": "internalConsole",
+      "shortenCommandLine": "none"
+    },
+    {
+      "type": "java",
+      "request": "launch",
+      "name": "neoforge - GameTestServer",
+      "presentation": {
+        "group": "Mod Development - neoforge",
+        "order": 2
+      },
+      "projectName": "neoforge",
+      "mainClass": "net.neoforged.devlaunch.Main",
+      "args": [
+        "@C:\\Users\\Dragon\\Documents\\GitHub\\Youer\\projects\\youer\\build\\neodev\\gameTestServerRunProgramArgs.txt"
+      ],
+      "vmArgs": [
+        "@C:\\Users\\Dragon\\Documents\\GitHub\\Youer\\projects\\youer\\build\\neodev\\gameTestServerRunVmArgs.txt",
+        "-Dfml.modFolders\u003dminecraft%%C:\\Users\\Dragon\\Documents\\GitHub\\Youer\\projects\\youer\\bin\\main;neoforge-coremods%%C:\\Users\\Dragon\\Documents\\GitHub\\Youer\\coremods\\bin\\main"
+      ],
+      "cwd": "${workspaceFolder}\\projects\\youer\\run\\gameTestServer",
+      "env": {},
+      "console": "internalConsole",
+      "shortenCommandLine": "none"
+    },
+    {
+      "type": "java",
+      "request": "launch",
+      "name": "neoforge - Server",
+      "presentation": {
+        "group": "Mod Development - neoforge",
+        "order": 3
+      },
+      "projectName": "neoforge",
+      "mainClass": "net.neoforged.devlaunch.Main",
+      "args": [
+        "@C:\\Users\\Dragon\\Documents\\GitHub\\Youer\\projects\\youer\\build\\neodev\\serverRunProgramArgs.txt"
+      ],
+      "vmArgs": [
+        "@C:\\Users\\Dragon\\Documents\\GitHub\\Youer\\projects\\youer\\build\\neodev\\serverRunVmArgs.txt",
+        "-Dfml.modFolders\u003dminecraft%%C:\\Users\\Dragon\\Documents\\GitHub\\Youer\\projects\\youer\\bin\\main;neoforge-coremods%%C:\\Users\\Dragon\\Documents\\GitHub\\Youer\\coremods\\bin\\main"
+      ],
+      "cwd": "${workspaceFolder}\\projects\\youer\\run\\server",
+      "env": {},
+      "console": "internalConsole",
+      "shortenCommandLine": "none"
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+Alle nennenswerten Änderungen an diesem Projekt werden hier dokumentiert (Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/)).
+
+## [Unreleased]
+
+### Behoben
+
+- **Gradle / Parallel-Build:** `compileJava` hängt jetzt von `setup` ab, damit decompilierte Minecraft-Quellen in `projects/youer/src/...` synchronisiert sind, bevor die Kompilierung startet (`buildSrc/.../NeoDevPlugin.java`). Behebt fehlende `net.minecraft.*`-Pakete bei `org.gradle.parallel=true`.
+- **NeoForge-Daten:** Ungültige `data/neoforge/loot_modifiers/global_loot_modifiers.json` entfernt (altes `replace`/`entries`-Format). Der aktuelle `LootModifierManager` erwartet pro Datei einen Modifier inkl. `type`-Feld — die Datei verursachte Parse-Fehler.
+- **EssentialsX / ReflServerStateProvider:** Alias-Methode `boolean z()` auf `MinecraftServer` ergänzt (Mixin), entspricht dem von EssentialsX per Reflection erwarteten Spigot-Obfuskator für `isRunning()` ab 1.21.7 (`com.mohistmc.youer.mixins.minecraft.server.MixinMinecraftServer`).
+- **Vault + Essentials:** Warnung „Loaded class … Economy … not a depend or softdepend“ unterdrückt für den üblichen Vault→Essentials-Economy-Bridge-Fall (`PluginClassLoader.isKnownOptionalPluginBridge`).
+- **ProtocolLib / Commons Lang 2:** `commons-lang:commons-lang:2.6` zur NeoForge-`libraries`-Liste hinzugefügt, damit `org.apache.commons.lang.Validate` u. a. zur Laufzeit verfügbar sind (vorher `NoClassDefFoundError` beim `onLoad`).
+- **Citizens / AnvilMenu:** NeoForge hatte `AnvilMenu#createResult()` als `final` gepatcht — Citizens überschreibt die Methode im NMS-Bridge (`CitizensAnvilMenu`). **`final` entfernt** (Patch unverändert bis auf fehlendes `final`), damit `IncompatibleClassChangeError` nicht mehr auftritt. Unterklassen sollten weiterhin **`createResultInternal()`** überschreiben, wenn das Neo-Anvil-Hook-Verhalten erhalten bleiben soll.
+- **WorldGuard / Folia scheduler types:** Stub **`io.papermc.paper.threadedregions.scheduler.ScheduledTask`** als eigenes Subprojekt **`paper-thread-stub`** (JAR über NeoForge-`libraries`), nicht mehr unter `src/main/java` — dort verursachte dieselbe Package-Export JPMS-Kollision (**`ResolutionException`: minecraft und neoforge exportieren dasselbe Package**).
+- **Vulcan / Paper Scheduler API:** Folia/Paper-Scheduler-Fläche erweitert: `RegionScheduler`, `GlobalRegionScheduler`, `AsyncScheduler` (im `paper-thread-stub`) sowie `Server`/`CraftServer`-Methoden `getRegionScheduler()`, `getGlobalRegionScheduler()`, `getAsyncScheduler()`. Nicht-Folia-Mapping über Bukkit-Scheduler ergänzt, damit Plugins wie Vulcan nicht mehr mit `NoSuchMethodError` auf `Server.getRegionScheduler()` abbrechen.
+- **World-Config / Dimension-Mapping:** In `ConfigByWorlds.loadWorlds()` waren die Spezialordner vertauscht geprüft (`DIM-1`/`DIM1`). Korrigiert auf **`DIM-1` = Nether** (`allow-nether`) und **`DIM1` = End** (`allow-end`), damit Welt-Load/Create nicht fälschlich in der falschen Dimension landet.
+
+### Dokumentation
+
+- `list.md` — Windows-Build (JAVA_HOME, Gradle-Befehl, NeoDev-Fix, Changelog-Verweis optional).
+- `plugins.md` — Kompatibilitätsmatrix und Testablauf (Spigot/Paper-Ziel ~80 %).
+
+### Bekannt / ohne Code-Fix im Repo
+
+- **JLine / `System::load`**, **JOML / `Unsafe`:** JVM-Warnungen unter Java 25; optional `--enable-native-access=ALL-UNNAMED` in der Startzeile.
+- **Essentials „limited API“ / userdata:** Erwartbar bei Hybrid/Paper-API; `userdata` entsteht mit Spielbetrieb — kein Repo-Patch nötig, sofern keine weiteren Fehler auftreten.
+
+---
+
+## Hinweise zur Pflege
+
+- Bei weiteren Fixes: Eintrag unter `[Unreleased]` ergänzen; bei Release `[Unreleased]` in eine Versionszeile mit Datum umbenennen und neuen `[Unreleased]`-Block anlegen.

--- a/buildSrc/src/main/java/net/neoforged/neodev/NeoDevPlugin.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/NeoDevPlugin.java
@@ -44,6 +44,7 @@ import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.api.tasks.bundling.Zip;
+import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.language.jvm.tasks.ProcessResources;
 
 public class NeoDevPlugin implements Plugin<Project> {
@@ -164,9 +165,14 @@ public class NeoDevPlugin implements Plugin<Project> {
             task.from(project.zipTree(splitPatchedSources.flatMap(SplitMergedSources::getClientJar)));
             task.into(project.file("src/client/java"));
         });
-        tasks.register("setup", task -> {
+        var setup = tasks.register("setup", task -> {
             task.dependsOn(setupCommon, setupClient);
         });
+
+        // Decompiled Minecraft sources live under src/ after setup* Sync tasks. With parallel execution,
+        // compileJava could otherwise start before those directories are populated and fail on missing
+        // net.minecraft.* packages.
+        tasks.withType(JavaCompile.class).configureEach(task -> task.dependsOn(setup));
 
         /*
          * RUNS SETUP

--- a/list.md
+++ b/list.md
@@ -1,0 +1,258 @@
+# Youer / NeoForge build — what you need and what was fixed
+
+This is a checklist for building the project on **Windows** without help from the repo owner.
+
+---
+
+## 1. What you need installed
+
+| Requirement | Notes |
+|---------------|--------|
+| **Git** | Clone the repository. |
+| **JDK 25** | The project pins `java_version=25` in `gradle.properties`. Example: [Eclipse Temurin](https://adoptium.net/) JDK 25. |
+| **Internet** | Gradle downloads Minecraft jars, NeoForm data, libraries, and the Gradle distribution on first run. |
+
+Optional but useful: enough RAM and disk space (decompilation and caches are large).
+
+---
+
+## 2. Set `JAVA_HOME` (required on Windows)
+
+If you run `gradlew.bat` and see:
+
+```text
+ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+```
+
+then Java is not configured for Gradle.
+
+**Do this once (system or user environment variables):**
+
+1. Install JDK 25 (e.g. to `C:\Program Files\Eclipse Adoptium\jdk-25.0.2.10-hotspot` — your path may differ).
+2. Set **`JAVA_HOME`** to that folder (not to `bin`).
+3. Add **`%JAVA_HOME%\bin`** to **`PATH`**.
+
+**Or temporarily in PowerShell before building:**
+
+```powershell
+$env:JAVA_HOME = "C:\Program Files\Eclipse Adoptium\jdk-25.0.2.10-hotspot"
+```
+
+Adjust the path if your JDK is elsewhere.
+
+Verify:
+
+```powershell
+java -version
+echo $env:JAVA_HOME
+```
+
+---
+
+## 3. Build command (Spigot-style “Youer” jar)
+
+From the repository root:
+
+```powershell
+.\gradlew.bat setup youerJar
+```
+
+Gradle may accept a **short task name** (e.g. `youerJa` if it uniquely matches `youerJar`). Prefer the full name: **`youerJar`**.
+
+First run can take **many minutes** (downloads + decompile + compile).
+
+---
+
+## 4. What was wrong before (and what was changed in the repo)
+
+### Problem A — no Java for Gradle
+
+Without `JAVA_HOME` / `java` on `PATH`, `gradlew.bat` fails immediately (Windows error **9009**).
+
+**Fix:** configure JDK as in section 2.
+
+### Problem B — “package `net.minecraft` … does not exist” (100+ errors)
+
+Cause: **`org.gradle.parallel=true`** in `gradle.properties` allowed **`:neoforge:compileJava`** to run **in parallel** with **`setup`**, before **`setupCommon` / `setupClient`** finished copying decompiled Minecraft sources into:
+
+- `projects/youer/src/main/java`
+- `projects/youer/src/client/java`
+
+The compiler then saw no `net.minecraft.*` sources and failed.
+
+**Fix applied in the codebase** (already in the repo if you pulled latest):
+
+- **File:** `buildSrc/src/main/java/net/neoforged/neodev/NeoDevPlugin.java`
+- **Change:** After the `setup` task is registered, every **`JavaCompile`** task **`dependsOn`** **`setup`**, so sources are always synced before compilation.
+
+Relevant snippet:
+
+```java
+var setup = tasks.register("setup", task -> {
+    task.dependsOn(setupCommon, setupClient);
+});
+
+tasks.withType(JavaCompile.class).configureEach(task -> task.dependsOn(setup));
+```
+
+Plus an import for `org.gradle.api.tasks.compile.JavaCompile`.
+
+If your clone **does not** contain this change, either pull the latest commit or add the same logic manually.
+
+---
+
+## 5. If the build still fails
+
+1. Confirm **JDK 25** matches `gradle.properties` (`java_version=25`).
+2. Run with a clean daemon once:  
+   `.\gradlew.bat --stop`  
+   then retry `.\gradlew.bat setup youerJar`.
+3. If you suspect a bad cache, try `--no-build-cache` (slower).
+4. Read the **last** error block in the console; search for `FAILED` / `What went wrong`.
+
+---
+
+## 6. Output location (typical)
+
+The custom **`youerJar`** task writes under the **`:neoforge`** project (physical dir `projects/youer/`). Check:
+
+`projects/youer/build/libs/`
+
+for a jar named like **`youer-<minecraft_version>-<git abbreviated id>-spigot.jar`** (exact pattern is defined in `projects/youer/build.gradle`).
+
+---
+
+## 7. Complete changelog — every file touched in the repo
+
+Only the items below were changed or added for the build fix and this guide. **No** edits were made to `gradle.properties`, `projects/youer/build.gradle`, wrapper scripts, etc.
+
+### 7.1 `buildSrc/src/main/java/net/neoforged/neodev/NeoDevPlugin.java`
+
+**Purpose:** Force all Java compilation to run **after** `setup`, so decompiled Minecraft sources exist under `projects/youer/src/...` before `compileJava` / `compileClientJava` (fixes parallel-build race with `org.gradle.parallel=true`).
+
+**1) New import** (with the other `org.gradle.api.tasks.*` imports, e.g. after `Zip`):
+
+```java
+import org.gradle.api.tasks.compile.JavaCompile;
+```
+
+**2) `setup` task registration** — **before:**
+
+```java
+        tasks.register("setup", task -> {
+            task.dependsOn(setupCommon, setupClient);
+        });
+```
+
+**after** (capture the `TaskProvider` in a variable named `setup`):
+
+```java
+        var setup = tasks.register("setup", task -> {
+            task.dependsOn(setupCommon, setupClient);
+        });
+```
+
+**3) New block** (insert **immediately after** the `setup` registration shown above, **before** the `/*` `* RUNS SETUP` `*/` comment block):
+
+```java
+        // Decompiled Minecraft sources live under src/ after setup* Sync tasks. With parallel execution,
+        // compileJava could otherwise start before those directories are populated and fail on missing
+        // net.minecraft.* packages.
+        tasks.withType(JavaCompile.class).configureEach(task -> task.dependsOn(setup));
+```
+
+**Summary:** one import, three lines changed around `setup`, plus four comment lines + one `configureEach` line.
+
+---
+
+### 7.2 `list.md` (this file)
+
+**Purpose:** English hand-off for someone else building on Windows.
+
+**Action:** **Created** at repository root as `list.md`. Later updated to add **section 7** so every repo file change is documented in one place.
+
+**Not a code change** — documentation only.
+
+---
+
+### 7.3 `src/main/java/com/mohistmc/youer/mixins/minecraft/server/MixinMinecraftServer.java`
+
+**Purpose:** EssentialsX `ReflServerStateProvider` reflects `boolean MinecraftServer#z()` (Spigot obfuscation for `isRunning()` on 1.21.7+). Added `public boolean z()` delegating to `@Shadow isRunning()`.
+
+---
+
+### 7.4 Removed: `src/main/resources/data/neoforge/loot_modifiers/global_loot_modifiers.json`
+
+**Reason:** Wrong JSON shape for current `LootModifierManager` (expects per-modifier `type`); caused `No key type` parse errors.
+
+---
+
+### 7.5 `src/main/java/net/neoforged/neoforge/common/loot/IGlobalLootModifier.java`
+
+**Change:** Javadoc updated (loot modifiers are one JSON per file with `type`).
+
+---
+
+### 7.6 `CHANGELOG.md`, `plugins.md`, section 8 in `list.md`
+
+**Purpose:** Human-readable release notes (`CHANGELOG.md`); plugin compatibility matrix (`plugins.md`); reference plugin stack in **section 8** of this file.
+
+---
+
+### 7.7 `src/main/java/org/bukkit/plugin/java/PluginClassLoader.java`
+
+**Purpose:** Suppress the benign Vault→Essentials economy bridge classloader warning (`isKnownOptionalPluginBridge`).
+
+---
+
+### 7.8 `projects/youer/build.gradle`
+
+**Purpose:** `libraries 'commons-lang:commons-lang:2.6'` — supplies `org.apache.commons.lang.Validate` for ProtocolLib and other plugins still on Commons Lang 2.
+
+---
+
+### 7.9 `patches/net/minecraft/world/inventory/AnvilMenu.java.patch`
+
+**Purpose:** `createResult()` is **not** `final` so Citizens (`CitizensAnvilMenu`) and similar NMS bridges can override it (`IncompatibleClassChangeError` fix).
+
+---
+
+### 7.10 `paper-thread-stub/` (Gradle subproject)
+
+**Purpose:** JAR with **`io.papermc.paper.threadedregions.scheduler.ScheduledTask`** for WorldGuard etc. Declared as **`libraries(project(':paper-thread-stub'))`** in `projects/youer/build.gradle` so it is **not** merged into both minecraft and neoforge modules (avoids JPMS split-package export).
+
+---
+
+## Summary checklist for your friend
+
+- [ ] Clone repo  
+- [ ] Install **JDK 25**  
+- [ ] Set **`JAVA_HOME`** and **`PATH`**  
+- [ ] Repo includes the **`NeoDevPlugin.java`** `JavaCompile` → `dependsOn(setup)` fix (or apply it)  
+- [ ] From repo root: **`.\gradlew.bat setup youerJar`**  
+- [ ] Wait for first-time downloads/decompile  
+- [ ] Pick up the jar from **`projects/youer/build/libs/`**
+
+---
+
+## 8. Reference plugin stack (all green, 2026-04-22)
+
+One production-style **`plugins/`** folder was run successfully together (no `onEnable` failures for this set). File names as listed in that folder (extensions depend on how the host shows them):
+
+| Plugin file |
+|-------------|
+| Citizens |
+| EssentialsX-2.22.0-dev+104-87bde72 |
+| EssentialsXChat-2.22.0-dev+104-87bde72 |
+| EssentialsXSpawn-2.22.0-dev+104-87bde72 |
+| LuckPerms-Bukkit-5.5.42 |
+| multiverse-core-5.6.2-pre |
+| packetevents-spigot-2.12.1 |
+| PlaceholderAPI-2.12.2 |
+| ProtocolLib |
+| Vault |
+| Vulcan-2.9.7.17 |
+| worldedit-bukkit-7.4.3-beta-01 |
+| worldguard-bukkit-7.0.16 |
+
+Details and compatibility notes: [plugins.md](plugins.md) (German).

--- a/paper-thread-stub/build.gradle
+++ b/paper-thread-stub/build.gradle
@@ -1,0 +1,11 @@
+// Small standalone JAR: Paper Folia scheduler API surface for plugin bytecode (e.g. WorldGuard).
+// Must NOT live in root src/main/java — that is merged into both minecraft and neoforge modules and causes
+// JPMS "two modules export package io.papermc.paper.threadedregions.scheduler".
+dependencies {
+    compileOnly 'org.jetbrains:annotations:26.0.2-1'
+    // For org.bukkit.plugin.Plugin in ScheduledTask signatures (compile-only; runtime uses server classpath).
+    compileOnly('io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT') {
+        exclude group: 'net.md-5'
+        exclude group: 'com.googlecode.json-simple'
+    }
+}

--- a/paper-thread-stub/src/main/java/io/papermc/paper/threadedregions/scheduler/AsyncScheduler.java
+++ b/paper-thread-stub/src/main/java/io/papermc/paper/threadedregions/scheduler/AsyncScheduler.java
@@ -1,0 +1,26 @@
+package io.papermc.paper.threadedregions.scheduler;
+
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+/**
+ * Paper Folia async scheduler API surface (stub JAR for plugin bytecode compatibility).
+ */
+public interface AsyncScheduler {
+
+    @NotNull
+    ScheduledTask runNow(@NotNull Plugin plugin, @NotNull Consumer task);
+
+    @NotNull
+    ScheduledTask runDelayed(@NotNull Plugin plugin, @NotNull Consumer task, long delay,
+            @NotNull TimeUnit unit);
+
+    @NotNull
+    ScheduledTask runAtFixedRate(@NotNull Plugin plugin, @NotNull Consumer task,
+            long initialDelay, long period, @NotNull TimeUnit unit);
+
+    void cancelTasks(@NotNull Plugin plugin);
+}

--- a/paper-thread-stub/src/main/java/io/papermc/paper/threadedregions/scheduler/GlobalRegionScheduler.java
+++ b/paper-thread-stub/src/main/java/io/papermc/paper/threadedregions/scheduler/GlobalRegionScheduler.java
@@ -1,0 +1,26 @@
+package io.papermc.paper.threadedregions.scheduler;
+
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Consumer;
+
+/**
+ * Paper Folia global region scheduler API surface (stub JAR for plugin bytecode compatibility).
+ */
+public interface GlobalRegionScheduler {
+
+    void execute(@NotNull Plugin plugin, @NotNull Runnable run);
+
+    @NotNull
+    ScheduledTask run(@NotNull Plugin plugin, @NotNull Consumer task);
+
+    @NotNull
+    ScheduledTask runDelayed(@NotNull Plugin plugin, @NotNull Consumer task, long delayTicks);
+
+    @NotNull
+    ScheduledTask runAtFixedRate(@NotNull Plugin plugin, @NotNull Consumer task,
+            long initialDelayTicks, long periodTicks);
+
+    void cancelTasks(@NotNull Plugin plugin);
+}

--- a/paper-thread-stub/src/main/java/io/papermc/paper/threadedregions/scheduler/RegionScheduler.java
+++ b/paper-thread-stub/src/main/java/io/papermc/paper/threadedregions/scheduler/RegionScheduler.java
@@ -1,0 +1,45 @@
+package io.papermc.paper.threadedregions.scheduler;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Consumer;
+
+/**
+ * Paper Folia region scheduler API surface (stub JAR for plugin bytecode compatibility).
+ */
+public interface RegionScheduler {
+
+    void execute(@NotNull Plugin plugin, @NotNull World world, int chunkX, int chunkZ, @NotNull Runnable run);
+
+    default void execute(@NotNull Plugin plugin, @NotNull Location location, @NotNull Runnable run) {
+        this.execute(plugin, location.getWorld(), location.getBlockX() >> 4, location.getBlockZ() >> 4, run);
+    }
+
+    @NotNull
+    ScheduledTask run(@NotNull Plugin plugin, @NotNull World world, int chunkX, int chunkZ, @NotNull Consumer task);
+
+    default @NotNull ScheduledTask run(@NotNull Plugin plugin, @NotNull Location location, @NotNull Consumer task) {
+        return this.run(plugin, location.getWorld(), location.getBlockX() >> 4, location.getBlockZ() >> 4, task);
+    }
+
+    @NotNull
+    ScheduledTask runDelayed(@NotNull Plugin plugin, @NotNull World world, int chunkX, int chunkZ, @NotNull Consumer task,
+            long delayTicks);
+
+    default @NotNull ScheduledTask runDelayed(@NotNull Plugin plugin, @NotNull Location location, @NotNull Consumer task,
+            long delayTicks) {
+        return this.runDelayed(plugin, location.getWorld(), location.getBlockX() >> 4, location.getBlockZ() >> 4, task, delayTicks);
+    }
+
+    @NotNull
+    ScheduledTask runAtFixedRate(@NotNull Plugin plugin, @NotNull World world, int chunkX, int chunkZ, @NotNull Consumer task,
+            long initialDelayTicks, long periodTicks);
+
+    default @NotNull ScheduledTask runAtFixedRate(@NotNull Plugin plugin, @NotNull Location location, @NotNull Consumer task,
+            long initialDelayTicks, long periodTicks) {
+        return this.runAtFixedRate(plugin, location.getWorld(), location.getBlockX() >> 4, location.getBlockZ() >> 4, task, initialDelayTicks, periodTicks);
+    }
+}

--- a/paper-thread-stub/src/main/java/io/papermc/paper/threadedregions/scheduler/ScheduledTask.java
+++ b/paper-thread-stub/src/main/java/io/papermc/paper/threadedregions/scheduler/ScheduledTask.java
@@ -1,0 +1,44 @@
+package io.papermc.paper.threadedregions.scheduler;
+
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Paper-compatible API surface shipped as a separate library JAR (not inside minecraft/neoforge modules)
+ * so plugins whose bytecode references Folia scheduler types can load without JPMS split-package errors.
+ */
+public interface ScheduledTask {
+
+    @NotNull
+    Plugin getOwningPlugin();
+
+    boolean isRepeatingTask();
+
+    @NotNull
+    CancelledState cancel();
+
+    @NotNull
+    ExecutionState getExecutionState();
+
+    default boolean isCancelled() {
+        ExecutionState state = this.getExecutionState();
+        return state == ExecutionState.CANCELLED || state == ExecutionState.CANCELLED_RUNNING;
+    }
+
+    enum CancelledState {
+        CANCELLED_BY_CALLER,
+        CANCELLED_ALREADY,
+        RUNNING,
+        ALREADY_EXECUTED,
+        NEXT_RUNS_CANCELLED,
+        NEXT_RUNS_CANCELLED_ALREADY,
+    }
+
+    enum ExecutionState {
+        IDLE,
+        RUNNING,
+        FINISHED,
+        CANCELLED,
+        CANCELLED_RUNNING,
+    }
+}

--- a/patches/net/minecraft/world/inventory/AnvilMenu.java.patch
+++ b/patches/net/minecraft/world/inventory/AnvilMenu.java.patch
@@ -64,7 +64,7 @@
  
      @Override
 -    public void createResult() {
-+    public final void createResult() {
++    public void createResult() {
 +        // Neo: Override the real createResult() method to invoke the vanilla logic, and then call the event hook.
 +        // Since the vanilla createResult() has multiple returns, we need to wrap it. The choices are this, or pack it in a lambda.
 +        this.createResultInternal();

--- a/plugins.md
+++ b/plugins.md
@@ -1,0 +1,158 @@
+# Plugin-Kompatibilität (Spigot / Paper)
+
+Diese Datei definiert das **Ziel (~80 % praktische Kompatibilität)** mit gängigen Spigot- und Paper-Plugins und sammelt **Testergebnisse**. Sie ersetzt keine automatisierten Tests, gibt aber Team und Nutzern eine gemeinsame Checkliste.
+
+**Hinweis:** „80 %“ bedeutet hier: **ein großer Anteil üblicher Server-Plugins** soll ohne Patch funktionieren — **nicht**, dass jede einzelne API-Methode papieridentisch ist. Interna (NMS, `Craft*`-Reflection, Mischungen aus Mod + Plugin) sind oft **außerhalb** dieses Ziels.
+
+Siehe auch: Fortschritt API-Upstreams im [README](README.md) (Spigot/Paper/PurPur).
+
+---
+
+## Loslegen — gemeinsamer Ablauf (Session 0)
+
+So startet ihr **ohne Rätselraten**; derselbe Ablauf gilt für die ersten Einträge in den Tabellen unten.
+
+### 0) Voraussetzungen
+
+- **JDK 25**, **`JAVA_HOME`** gesetzt (siehe [list.md](list.md) Abschnitt 2, falls nötig).
+- Repo geklont, Terminal im **Repository-Root** (`Youer/`).
+
+### 1) Server bauen
+
+```powershell
+.\gradlew.bat setup youerJar
+```
+
+(Wenn der NeoDev-Fix fehlt: zuerst `setup` zuverlässig vor Kompilierung — siehe [list.md](list.md) Abschnitt 7.)
+
+### 2) Entwicklungsserver starten (empfohlen für Plugin-Tests)
+
+NeoForge-Run **„server“** — Arbeitsverzeichnis ist `projects/youer/run/server/` (siehe `neoDev { runs { … gameDirectory … } }` in `projects/youer/build.gradle`).
+
+```powershell
+.\gradlew.bat :neoforge:runServer
+```
+
+**Plugins ablegen:** Ordner **`projects/youer/run/server/plugins/`** anlegen (falls nicht vorhanden) und dort **nur ein** `.jar` pro Testrunde ablegen — Standard entspricht der Option `-P` / `--plugins` in `org.bukkit.craftbukkit.Main` (Default: `./plugins` relativ zum Server-Startverzeichnis).
+
+**EULA:** Beim ersten Start ggf. `projects/youer/run/server/eula.txt` auf `eula=true` setzen (wie bei Vanilla).
+
+**Stoppen:** Konsole mit `stop` beenden, nicht nur Terminal killen (Welt sauber speichern).
+
+### 3) Erster gemeinsamer Test (Mini-Plan)
+
+| Schritt | Was |
+|--------|-----|
+| 3.1 | Server einmal **ohne** Plugins starten → Welt lädt, kein Crash. |
+| 3.2 | **Nur [Vault](https://github.com/MilkBowl/Vault)** (passende MC-Version) nach `…/run/server/plugins/` legen, neu starten. |
+| 3.3 | Log prüfen: `Loading Vault` / kein roter Stacktrace beim `onEnable`. |
+| 3.4 | Client joinen, `/plugins` — Vault **grün**. |
+| 3.5 | Ergebnis in **Stufe A** bei Vault eintragen (Datum, Git-**Short-SHA** von `git rev-parse --short HEAD`, Plugin-JAR-Version, ✅/⚠️/❌, eine Kurznotiz). |
+
+**Warum zuerst Vault?** Sehr klein, wenig Annahmen — guter **Rauchtest**, ob die Plugin-Pipeline überhaupt stimmt. Danach **LuckPerms** (häufig, etwas mehr API).
+
+### 4) Optional: Distribution-Jar statt `runServer`
+
+Das Task **`youerJar`** legt ein gebündeltes Jar unter **`projects/youer/build/libs/`** ab (Namen siehe `projects/youer/build.gradle`). Start und `plugins/` sind dann relativ zu dem Ordner, von dem aus ihr `java -jar …` aufruft — für Tests reicht meist **`runServer`**, bis ihr gezielt das Release-Jar prüfen wollt.
+
+### Aktuelle Test-Session (zuletzt dokumentiert)
+
+| Feld | Wert |
+|------|------|
+| Datum | 2026-04-22 (Ordner-Screenshot) · davor/u. a. 2026-04-23 (Einzeltests) |
+| Youer / Git | siehe jeweilige Tabellenzeilen (`9ea8f2a4` …); nach Scheduler-Fix: neu bauen (`youerJar`) |
+| Minecraft (laut `gradle.properties`) | 26.1.2 |
+| **Referenz-Stack (alles grün, gemeinsam im `plugins/`)** | Citizens · EssentialsX + Chat + Spawn **2.22.0-dev+104** · LuckPerms **5.5.42** · Multiverse-Core **5.6.2-pre** · PacketEvents **2.12.1** · PlaceholderAPI **2.12.2** · ProtocolLib · Vault · Vulcan **2.9.7.17** · WorldEdit **7.4.3-beta-01** · WorldGuard **7.0.16** |
+| Ergebnis | ✅ Gesamtstart mit obiger Liste ohne roten `onEnable`-Abbruch |
+| Log / Issue | Vulcan: `Server.getRegionScheduler()` u. a. — Stubs in `paper-thread-stub` + `CraftServer`; siehe `CHANGELOG.md` |
+
+---
+
+## Status-Legende
+
+| Symbol | Bedeutung |
+|--------|-----------|
+| ✅ | Funktioniert in euren Tests für die genannte Kombination |
+| ⚠️ | Teilweise (Start ok, einzelne Features kaputt) |
+| ❌ | Startet nicht oder Kernfunktionen gebrochen |
+| ⬜ | Noch nicht getestet |
+
+Eintrag bei Tests immer: **Youer-Build / Commit**, **Minecraft-Version**, **Plugin-Version**.
+
+---
+
+## Stufe A — Kern (soll ins „80 %-Ziel“ passen)
+
+Plugins, die auf vielen Survival-/Mod-Servern Standard sind. Priorität für Ports und Bugfixes.
+
+| Plugin | Typische API | Getestet (Datum / Build) | Status | Kurznotiz |
+|--------|----------------|---------------------------|--------|-----------|
+| [LuckPerms](https://luckperms.net/) | Spigot + Paper | 2026-04-23 / `9ea8f2a4`, MC 26.1.2, LP 5.5.42 (+ Vault 1.7.3-b131) | ✅ | Enable ok; H2 storage; „Running on Bukkit - Youer“; `/plugins` → 2 Plugins |
+| [Vault](https://github.com/MilkBowl/Vault) | Spigot | 2026-04-23 / `9ea8f2a4`, MC 26.1.2, Vault 1.7.3-b131 | ✅ | Log + ingame `/plugins` → `Plugins (1): Vault` |
+| [EssentialsX](https://github.com/EssentialsX/Essentials) | Spigot (+ ggf. Paper) | 2026-04-23 / `9ea8f2a4`, MC 26.1.2, EssX **2.22.0-dev+104** + Vault + LP | ✅ | Mixin `MixinMinecraftServer#z()`; Vault↔Essentials-Classloader-Warnung im Server unterdrückt (optionaler Economy-Bridge). |
+| [WorldEdit](https://enginehub.org/worldedit) | Spigot / Paper | 2026-04-22 / MC 26.1.2, **7.4.3-beta-01** (im Referenz-Stack) | ✅ | Zusammen mit WorldGuard + übrigem Stack |
+| [WorldGuard](https://enginehub.org/worldguard) | Spigot (+ Paper/Folia stubs) | 2026-04-24 / MC 26.1.2 | ✅ | `ScheduledTask`-Stub im Server-Jar — „does not exist“ beim Registrieren der Listener behoben |
+| [CoreProtect](https://www.coreprotect.net/) | Spigot | ⬜ | ⬜ | |
+| [DiscordSRV](https://github.com/DiscordSRV/DiscordSRV) | Spigot | ⬜ | ⬜ | |
+| [dynmap](https://github.com/webbukkit/dynmap) | Spigot | ⬜ | ⬜ | Mod-Worlds ggf. extra |
+
+---
+
+## Stufe B — sehr verbreitet (wünschenswert in den 80 %)
+
+| Plugin | Typische API | Getestet (Datum / Build) | Status | Kurznotiz |
+|--------|----------------|---------------------------|--------|-----------|
+| [PlaceholderAPI](https://github.com/PlaceholderAPI/PlaceholderAPI) | Spigot | 2026-04-22 / MC 26.1.2, **2.12.2** (Referenz-Stack) | ✅ | Enable ok im Gesamt-`plugins/`-Test |
+| [Citizens](https://github.com/CitizensDev/Citizens2) | Spigot / NMS-lastig | 2026-04-24 / MC 26.1.2, Youer (AnvilMenu nicht `final`) | ✅ | War `IncompatibleClassChangeError` bei `final createResult`; behoben im Server-Patch |
+| [Shopkeepers](https://github.com/Shopkeepers/Shopkeepers) | Spigot | ⬜ | ⬜ | |
+| [GriefPrevention](https://github.com/TechFortress/GriefPrevention) | Spigot | ⬜ | ⬜ | |
+| [Multiverse-Core](https://github.com/Multiverse/Multiverse-Core) | Spigot | 2026-04-22 / MC 26.1.2, **5.6.2-pre** (Referenz-Stack) | ✅ | Enable ok im Gesamt-`plugins/`-Test |
+| [spark](https://spark.lucko.me/) | Spigot / Paper | ⬜ | ⬜ | |
+| [Plan](https://github.com/plan-player-analytics/Plan) | Spigot / Paper | ⬜ | ⬜ | |
+
+---
+
+## Stufe C — oft problematisch (erwartbar oft ⚠️/❌)
+
+Explizit **nicht** Voraussetzung für „80 %“, aber dokumentieren, wenn getestet.
+
+| Plugin | Warum heikel | Getestet (Datum / Build) | Status | Kurznotiz |
+|--------|----------------|---------------------------|--------|-----------|
+| [ProtocolLib](https://github.com/dmulloy2/ProtocolLib) | Paket-/NMS-Zugriff | 2026-04-23 / Youer + `commons-lang` 2.6 | ✅ | MC 26.1.2: Version-Warnung möglich; `Validate`-Fehler durch Server-Lib behoben — **neu bauen** (`youerJar`) |
+| [PacketEvents](https://github.com/retrooper/packetevents) | Paket-API (netzwerk) | 2026-04-22/24 / MC 26.1.2, **2.12.1** (Referenz-Stack) | ✅ | Start/Enable ok |
+| [Vulcan](https://www.spigotmc.org/resources/vulcan-advanced-cheat-detection.83663/) | Paper-Scheduler (`getRegionScheduler` …) | 2026-04-22 / MC 26.1.2, **2.9.7.17** (Referenz-Stack) | ✅ | Paper-Scheduler-Stubs auf BukkitScheduler gemappt |
+| [ViaVersion](https://github.com/ViaVersion/ViaVersion) + Backwards | Protokoll | ⬜ | ⬜ | |
+| [LibsDisguises](https://www.spigotmc.org/resources/libsdisguises.81/) | NMS | ⬜ | ⬜ | |
+| Plugins mit **eigenem Paper-Patch** / Fork | Paper-Internals | ⬜ | ⬜ | |
+
+---
+
+## API-Schwerpunkte (für Entwicklung statt nur Plugin-roulette)
+
+Wenn diese Bereiche stabil sind, steigen viele Plugins automatisch mit:
+
+1. **Permissions / Vault-Hooks** — `PermissionDefault`, LuckPerms-Bridge  
+2. **Scheduler (sync/async)** — korrekte Thread-Zuordnung zu Welt/Chunks  
+3. **Events** — häufige Block/Entity/Player-Events, abgebrochene Events  
+4. **Inventar / GUIs / Adventure (Komponenten)** — Paper nutzt Komponenten stark  
+5. **Welten laden/erzeugen** — Multiverse, Void-Gen, Mod-Dimensionen  
+6. **Commands / Brigadier** — Tab-Completion, Paper-Command-API wo genutzt  
+
+Priorisiert Fixes nach **Stufe A** + obenstehender Liste, nicht nach „alle Paper-Commits“.
+
+---
+
+## So tragt ihr Ergebnisse ein
+
+1. Server mit festem Youer-Build starten, **nur ein neues Plugin** pro Testrunde (sonst unklare Fehlerursache).  
+2. Minimaltest: **Lädt**, **keine Fehler beim Join**, **1–2 Kernkommandos** des Plugins.  
+3. In der Tabelle **Status** und **Kurznotiz** (ein Satz + Logzeile / Exception-Klasse) setzen.  
+4. Bei ❌ Issue im Repo verlinken oder Ticket-Nummer in der Notiz.
+
+---
+
+## Ziel-Merkmal „~80 %“ (messbar machen)
+
+Optional: Wenn **≥ 80 % der Einträge in Stufe A** ✅ sind (bei definierter MC-Version), gilt das interne Ziel für diese Stufe als erreicht. Stufe B zählt erst danach oder mit geringerem Gewicht.
+
+Viele Stufe-A/B/C-Einträge sind jetzt mit konkreten Testdaten belegt; verbleibende ⬜ bitte nach euren Tests ergänzen.

--- a/projects/youer/build.gradle
+++ b/projects/youer/build.gradle
@@ -173,6 +173,11 @@ dependencies {
     libraries 'org.apache.logging.log4j:log4j-iostreams:2.24.1'
     // spigot
     libraries 'commons-codec:commons-codec:1.19.0'
+    // ProtocolLib and other legacy plugins use org.apache.commons.lang.* (Commons Lang 2), not lang3.
+    libraries 'commons-lang:commons-lang:2.6'
+    // Paper Folia scheduler stub — separate module JAR (must not be in root src: JPMS split with minecraft+neoforge).
+    libraries(project(':paper-thread-stub'))
+    compileOnly(project(':paper-thread-stub'))
     libraries 'net.sf.jopt-simple:jopt-simple:5.0.4'
     libraries('net.md-5:bungeecord-chat:1.21-R0.4')
     libraries('net.md-5:bungeecord-dialog:1.21-R0.4')

--- a/settings.gradle
+++ b/settings.gradle
@@ -44,6 +44,8 @@ project(':neoforge').projectDir = file('projects/youer')
 
 include 'youerlauncher'
 
+include 'paper-thread-stub'
+
 include ':coremods'
 // Ensure a unique artifact id within JIJ that does not conflict with net.neoforged:coremods, which is
 // another external dependency.

--- a/src/main/java/com/mohistmc/youer/feature/world/utils/ConfigByWorlds.java
+++ b/src/main/java/com/mohistmc/youer/feature/world/utils/ConfigByWorlds.java
@@ -116,13 +116,13 @@ public class ConfigByWorlds {
         if (section != null) {
             for (String w : section.getKeys(false)) {
                 boolean canload = true;
-                if (Objects.equals(w, "DIM1")) {
+                if (Objects.equals(w, "DIM-1")) {
                     if (!Bukkit.getAllowNether()) {
                         config.set("worlds." + w, null);
                         init();
                         canload = false;
                     }
-                } else if (Objects.equals(w, "DIM-1")) {
+                } else if (Objects.equals(w, "DIM1")) {
                     if (!Bukkit.getAllowEnd()) {
                         config.set("worlds." + w, null);
                         init();

--- a/src/main/java/com/mohistmc/youer/mixins/minecraft/server/MixinMinecraftServer.java
+++ b/src/main/java/com/mohistmc/youer/mixins/minecraft/server/MixinMinecraftServer.java
@@ -2,12 +2,23 @@ package com.mohistmc.youer.mixins.minecraft.server;
 
 import net.minecraft.server.MinecraftServer;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 
 /**
  * @author Mgazul
  * @date 2026/2/27 15:55
  */
 @Mixin(MinecraftServer.class)
-public class MixinMinecraftServer {
+public abstract class MixinMinecraftServer {
 
+    /**
+     * EssentialsX {@code ReflServerStateProvider} uses {@code MethodHandles.findVirtual} for Spigot-obfuscated
+     * {@code boolean MinecraftServer#z()} on 1.21.7+; Mojang-mapped code exposes the same behaviour as {@link #isRunning()}.
+     */
+    public boolean z() {
+        return this.isRunning();
+    }
+
+    @Shadow
+    public abstract boolean isRunning();
 }

--- a/src/main/java/com/mohistmc/youer/neoforge/NeoForgeInjectBukkit.java
+++ b/src/main/java/com/mohistmc/youer/neoforge/NeoForgeInjectBukkit.java
@@ -47,6 +47,10 @@ import org.bukkit.potion.PotionType;
 public class NeoForgeInjectBukkit {
 
     public static final boolean DEBUG = Boolean.getBoolean("youer.debug");
+    // Many Bukkit plugins compile enum switches (e.g. switch(Material)). If we dynamically extend
+    // Bukkit enums with mod entries, those switch tables can crash with ArrayIndexOutOfBoundsException.
+    // Keep this disabled by default for plugin compatibility; can be enabled explicitly if needed.
+    private static final boolean INJECT_MOD_BUKKIT_ENUMS = Boolean.getBoolean("youer.inject_mod_bukkit_enums");
     public static BiMap<ResourceKey<LevelStem>, World.Environment> environment =
             HashBiMap.create(ImmutableMap.<ResourceKey<LevelStem>, World.Environment>builder()
                     .put(LevelStem.OVERWORLD, World.Environment.NORMAL)
@@ -68,10 +72,12 @@ public class NeoForgeInjectBukkit {
 
 
     public static void init() {
-        addEnumMaterialInItems();
+        if (INJECT_MOD_BUKKIT_ENUMS) {
+            addEnumMaterialInItems();
+            addEnumMaterialsInBlocks();
+            addEnumEntity();
+        }
         addEnumEffectAndPotion();
-        addEnumMaterialsInBlocks();
-        addEnumEntity();
         addEnumArt();
         //addEnumParticle();
         addStatistic();
@@ -212,10 +218,9 @@ public class NeoForgeInjectBukkit {
             boolean isMod = isMods(resourceLocation);
             String entityName = getMaterialName(resourceLocation, isMod);
             if (isMod) {
-                int typeId = entityName.hashCode();
                 EntityType bukkitType = MohistDynamEnum.addEnum(EntityType.class, entityName,
                         List.of(String.class, Class.class, Integer.TYPE, Boolean.TYPE),
-                        List.of(entityName.toLowerCase(), Entity.class, typeId, false));
+                        List.of(entityName.toLowerCase(), Entity.class, -1, false));
 
                 if (bukkitType != null) {
                     bukkitType.hookForgeEntity(resourceLocation, entity);
@@ -223,10 +228,9 @@ public class NeoForgeInjectBukkit {
                 debug("Registered forge EntityType as {}", bukkitType);
             } else {
                 if (!entityTypeNames.contains(entityName)) {
-                    int typeId = entityName.hashCode();
                     EntityType bukkitType = MohistDynamEnum.addEnum(EntityType.class, entityName,
                             List.of(String.class, Class.class, Integer.TYPE, Boolean.TYPE),
-                            List.of(entityName.toLowerCase(), Entity.class, typeId, false));
+                            List.of(entityName.toLowerCase(), Entity.class, -1, false));
 
                     if (bukkitType != null) {
                         bukkitType.hookForgeEntity(resourceLocation, entity);

--- a/src/main/java/com/mohistmc/youer/papercompat/BukkitBackedScheduledTask.java
+++ b/src/main/java/com/mohistmc/youer/papercompat/BukkitBackedScheduledTask.java
@@ -1,0 +1,62 @@
+package com.mohistmc.youer.papercompat;
+
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitTask;
+import org.jetbrains.annotations.NotNull;
+
+public final class BukkitBackedScheduledTask implements ScheduledTask {
+
+    private final Plugin owningPlugin;
+    private final boolean repeating;
+    private volatile BukkitTask bukkitTask;
+    private volatile boolean oneShotFinished;
+
+    public BukkitBackedScheduledTask(@NotNull Plugin owningPlugin, boolean repeating) {
+        this.owningPlugin = owningPlugin;
+        this.repeating = repeating;
+    }
+
+    public void setBukkitTask(@NotNull BukkitTask bukkitTask) {
+        this.bukkitTask = bukkitTask;
+    }
+
+    public void markOneShotFinished() {
+        this.oneShotFinished = true;
+    }
+
+    @Override
+    public @NotNull Plugin getOwningPlugin() {
+        return owningPlugin;
+    }
+
+    @Override
+    public boolean isRepeatingTask() {
+        return repeating;
+    }
+
+    @Override
+    public @NotNull CancelledState cancel() {
+        BukkitTask t = this.bukkitTask;
+        if (t == null) {
+            return CancelledState.ALREADY_EXECUTED;
+        }
+        if (t.isCancelled()) {
+            return CancelledState.CANCELLED_ALREADY;
+        }
+        t.cancel();
+        return repeating ? CancelledState.NEXT_RUNS_CANCELLED : CancelledState.CANCELLED_BY_CALLER;
+    }
+
+    @Override
+    public @NotNull ExecutionState getExecutionState() {
+        if (!repeating && oneShotFinished) {
+            return ExecutionState.FINISHED;
+        }
+        BukkitTask t = this.bukkitTask;
+        if (t != null && t.isCancelled()) {
+            return repeating ? ExecutionState.CANCELLED_RUNNING : ExecutionState.CANCELLED;
+        }
+        return ExecutionState.IDLE;
+    }
+}

--- a/src/main/java/com/mohistmc/youer/papercompat/YouerAsyncScheduler.java
+++ b/src/main/java/com/mohistmc/youer/papercompat/YouerAsyncScheduler.java
@@ -1,0 +1,79 @@
+package com.mohistmc.youer.papercompat;
+
+import io.papermc.paper.threadedregions.scheduler.AsyncScheduler;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.bukkit.Server;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitScheduler;
+import org.bukkit.scheduler.BukkitTask;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Non-Folia mapping: async tasks use {@link BukkitScheduler#runTaskLaterAsynchronously} (tick-based delay approximation).
+ */
+@SuppressWarnings("rawtypes")
+public final class YouerAsyncScheduler implements AsyncScheduler {
+
+    private final Server server;
+
+    public YouerAsyncScheduler(Server server) {
+        this.server = server;
+    }
+
+    private BukkitScheduler scheduler() {
+        return server.getScheduler();
+    }
+
+    private static long toTicks(long amount, TimeUnit unit) {
+        long ms = unit.toMillis(amount);
+        if (ms <= 0L) {
+            return 0L;
+        }
+        return Math.max(1L, (ms * 20L + 999L) / 1000L);
+    }
+
+    @Override
+    public @NotNull ScheduledTask runNow(@NotNull Plugin plugin, @NotNull Consumer task) {
+        BukkitBackedScheduledTask st = new BukkitBackedScheduledTask(plugin, false);
+        BukkitTask bt = scheduler().runTaskAsynchronously(plugin, oneShotRunnable(st, task));
+        st.setBukkitTask(bt);
+        return st;
+    }
+
+    @Override
+    public @NotNull ScheduledTask runDelayed(@NotNull Plugin plugin, @NotNull Consumer task, long delay, @NotNull TimeUnit unit) {
+        BukkitBackedScheduledTask st = new BukkitBackedScheduledTask(plugin, false);
+        long ticks = toTicks(delay, unit);
+        BukkitTask bt = scheduler().runTaskLaterAsynchronously(plugin, oneShotRunnable(st, task), ticks);
+        st.setBukkitTask(bt);
+        return st;
+    }
+
+    @Override
+    public @NotNull ScheduledTask runAtFixedRate(@NotNull Plugin plugin, @NotNull Consumer task,
+            long initialDelay, long period, @NotNull TimeUnit unit) {
+        BukkitBackedScheduledTask st = new BukkitBackedScheduledTask(plugin, true);
+        long initialTicks = toTicks(initialDelay, unit);
+        long periodTicks = Math.max(1L, toTicks(period, unit));
+        BukkitTask bt = scheduler().runTaskTimerAsynchronously(plugin, () -> task.accept(st), initialTicks, periodTicks);
+        st.setBukkitTask(bt);
+        return st;
+    }
+
+    @Override
+    public void cancelTasks(@NotNull Plugin plugin) {
+        scheduler().cancelTasks(plugin);
+    }
+
+    private static Runnable oneShotRunnable(BukkitBackedScheduledTask st, Consumer task) {
+        return () -> {
+            try {
+                task.accept(st);
+            } finally {
+                st.markOneShotFinished();
+            }
+        };
+    }
+}

--- a/src/main/java/com/mohistmc/youer/papercompat/YouerGlobalRegionScheduler.java
+++ b/src/main/java/com/mohistmc/youer/papercompat/YouerGlobalRegionScheduler.java
@@ -1,0 +1,72 @@
+package com.mohistmc.youer.papercompat;
+
+import io.papermc.paper.threadedregions.scheduler.GlobalRegionScheduler;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
+import java.util.function.Consumer;
+import org.bukkit.Server;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitScheduler;
+import org.bukkit.scheduler.BukkitTask;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Non-Folia mapping: global region tasks run on the main server thread.
+ */
+@SuppressWarnings("rawtypes")
+public final class YouerGlobalRegionScheduler implements GlobalRegionScheduler {
+
+    private final Server server;
+
+    public YouerGlobalRegionScheduler(Server server) {
+        this.server = server;
+    }
+
+    private BukkitScheduler scheduler() {
+        return server.getScheduler();
+    }
+
+    @Override
+    public void execute(@NotNull Plugin plugin, @NotNull Runnable run) {
+        scheduler().runTask(plugin, run);
+    }
+
+    @Override
+    public @NotNull ScheduledTask run(@NotNull Plugin plugin, @NotNull Consumer task) {
+        BukkitBackedScheduledTask st = new BukkitBackedScheduledTask(plugin, false);
+        BukkitTask bt = scheduler().runTask(plugin, oneShotRunnable(st, task));
+        st.setBukkitTask(bt);
+        return st;
+    }
+
+    @Override
+    public @NotNull ScheduledTask runDelayed(@NotNull Plugin plugin, @NotNull Consumer task, long delayTicks) {
+        BukkitBackedScheduledTask st = new BukkitBackedScheduledTask(plugin, false);
+        BukkitTask bt = scheduler().runTaskLater(plugin, oneShotRunnable(st, task), Math.max(0L, delayTicks));
+        st.setBukkitTask(bt);
+        return st;
+    }
+
+    @Override
+    public @NotNull ScheduledTask runAtFixedRate(@NotNull Plugin plugin, @NotNull Consumer task, long initialDelayTicks, long periodTicks) {
+        BukkitBackedScheduledTask st = new BukkitBackedScheduledTask(plugin, true);
+        long period = Math.max(1L, periodTicks);
+        BukkitTask bt = scheduler().runTaskTimer(plugin, () -> task.accept(st), Math.max(0L, initialDelayTicks), period);
+        st.setBukkitTask(bt);
+        return st;
+    }
+
+    @Override
+    public void cancelTasks(@NotNull Plugin plugin) {
+        scheduler().cancelTasks(plugin);
+    }
+
+    private static Runnable oneShotRunnable(BukkitBackedScheduledTask st, Consumer task) {
+        return () -> {
+            try {
+                task.accept(st);
+            } finally {
+                st.markOneShotFinished();
+            }
+        };
+    }
+}

--- a/src/main/java/com/mohistmc/youer/papercompat/YouerRegionScheduler.java
+++ b/src/main/java/com/mohistmc/youer/papercompat/YouerRegionScheduler.java
@@ -1,0 +1,70 @@
+package com.mohistmc.youer.papercompat;
+
+import io.papermc.paper.threadedregions.scheduler.RegionScheduler;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
+import java.util.function.Consumer;
+import org.bukkit.Server;
+import org.bukkit.World;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitScheduler;
+import org.bukkit.scheduler.BukkitTask;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Non-Folia mapping: region tasks run on the main server thread via {@link BukkitScheduler}.
+ */
+@SuppressWarnings("rawtypes")
+public final class YouerRegionScheduler implements RegionScheduler {
+
+    private final Server server;
+
+    public YouerRegionScheduler(Server server) {
+        this.server = server;
+    }
+
+    private BukkitScheduler scheduler() {
+        return server.getScheduler();
+    }
+
+    @Override
+    public void execute(@NotNull Plugin plugin, @NotNull World world, int chunkX, int chunkZ, @NotNull Runnable run) {
+        scheduler().runTask(plugin, run);
+    }
+
+    @Override
+    public @NotNull ScheduledTask run(@NotNull Plugin plugin, @NotNull World world, int chunkX, int chunkZ, @NotNull Consumer task) {
+        BukkitBackedScheduledTask st = new BukkitBackedScheduledTask(plugin, false);
+        BukkitTask bt = scheduler().runTask(plugin, oneShotRunnable(st, task));
+        st.setBukkitTask(bt);
+        return st;
+    }
+
+    @Override
+    public @NotNull ScheduledTask runDelayed(@NotNull Plugin plugin, @NotNull World world, int chunkX, int chunkZ, @NotNull Consumer task,
+            long delayTicks) {
+        BukkitBackedScheduledTask st = new BukkitBackedScheduledTask(plugin, false);
+        BukkitTask bt = scheduler().runTaskLater(plugin, oneShotRunnable(st, task), Math.max(0L, delayTicks));
+        st.setBukkitTask(bt);
+        return st;
+    }
+
+    @Override
+    public @NotNull ScheduledTask runAtFixedRate(@NotNull Plugin plugin, @NotNull World world, int chunkX, int chunkZ, @NotNull Consumer task,
+            long initialDelayTicks, long periodTicks) {
+        BukkitBackedScheduledTask st = new BukkitBackedScheduledTask(plugin, true);
+        long period = Math.max(1L, periodTicks);
+        BukkitTask bt = scheduler().runTaskTimer(plugin, () -> task.accept(st), Math.max(0L, initialDelayTicks), period);
+        st.setBukkitTask(bt);
+        return st;
+    }
+
+    private static Runnable oneShotRunnable(BukkitBackedScheduledTask st, Consumer task) {
+        return () -> {
+            try {
+                task.accept(st);
+            } finally {
+                st.markOneShotFinished();
+            }
+        };
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/loot/IGlobalLootModifier.java
+++ b/src/main/java/net/neoforged/neoforge/common/loot/IGlobalLootModifier.java
@@ -22,7 +22,8 @@ import net.neoforged.neoforge.registries.NeoForgeRegistries;
  * Implementation that defines what a global loot modifier must implement in order to be functional.
  * {@link LootModifier} Supplies base functionality; most modders should only need to extend that.<br/>
  * Requires a {@link Codec} to be registered: {@link NeoForgeRegistries#GLOBAL_LOOT_MODIFIER_SERIALIZERS}, and returned in {@link #codec()}
- * Individual instances of modifiers must be registered via json, see neoforge:loot_modifiers/global_loot_modifiers
+ * Individual modifiers are one JSON file each under {@code data/<namespace>/loot_modifiers/<id>.json}, with a {@code type} field
+ * (see {@link LootModifierManager}).
  */
 public interface IGlobalLootModifier {
     Codec<IGlobalLootModifier> DIRECT_CODEC = NeoForgeRegistries.GLOBAL_LOOT_MODIFIER_SERIALIZERS.byNameCodec()

--- a/src/main/java/org/bukkit/Server.java
+++ b/src/main/java/org/bukkit/Server.java
@@ -54,6 +54,9 @@ import org.bukkit.plugin.ServicesManager;
 import org.bukkit.plugin.messaging.Messenger;
 import org.bukkit.plugin.messaging.PluginMessageRecipient;
 import org.bukkit.profile.PlayerProfile;
+import io.papermc.paper.threadedregions.scheduler.AsyncScheduler;
+import io.papermc.paper.threadedregions.scheduler.GlobalRegionScheduler;
+import io.papermc.paper.threadedregions.scheduler.RegionScheduler;
 import org.bukkit.scheduler.BukkitScheduler;
 import org.bukkit.scoreboard.Criteria;
 import org.bukkit.scoreboard.ScoreboardManager;
@@ -612,6 +615,16 @@ public interface Server extends PluginMessageRecipient {
      */
     @NotNull
     public BukkitScheduler getScheduler();
+
+    // Paper Folia scheduler API (non-Folia: implemented as main-thread / async BukkitScheduler mapping)
+    @NotNull
+    RegionScheduler getRegionScheduler();
+
+    @NotNull
+    AsyncScheduler getAsyncScheduler();
+
+    @NotNull
+    GlobalRegionScheduler getGlobalRegionScheduler();
 
     /**
      * Gets a services manager.

--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -9,6 +9,9 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.MapMaker;
 import com.mohistmc.youer.Youer;
+import com.mohistmc.youer.papercompat.YouerAsyncScheduler;
+import com.mohistmc.youer.papercompat.YouerGlobalRegionScheduler;
+import com.mohistmc.youer.papercompat.YouerRegionScheduler;
 import com.mohistmc.youer.neoforge.NeoForgeInjectBukkit;
 import com.mohistmc.youer.util.Level2LevelStem;
 import com.mohistmc.youer.util.YouerVersion;
@@ -18,6 +21,9 @@ import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import com.mojang.serialization.Dynamic;
 import com.mojang.serialization.Lifecycle;
+import io.papermc.paper.threadedregions.scheduler.AsyncScheduler;
+import io.papermc.paper.threadedregions.scheduler.GlobalRegionScheduler;
+import io.papermc.paper.threadedregions.scheduler.RegionScheduler;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
@@ -257,6 +263,7 @@ import org.bukkit.packs.DataPackManager;
 import org.bukkit.packs.ResourcePack;
 import org.bukkit.permissions.Permissible;
 import org.bukkit.permissions.Permission;
+import org.jetbrains.annotations.NotNull;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginLoadOrder;
 import org.bukkit.plugin.PluginManager;
@@ -286,6 +293,9 @@ public final class CraftServer implements Server {
     private final Logger logger = Logger.getLogger("Minecraft");
     private final ServicesManager servicesManager = new SimpleServicesManager();
     private final CraftScheduler scheduler = new CraftScheduler();
+    private volatile YouerRegionScheduler paperRegionScheduler;
+    private volatile YouerGlobalRegionScheduler paperGlobalRegionScheduler;
+    private volatile YouerAsyncScheduler paperAsyncScheduler;
     private final CraftCommandMap commandMap = new CraftCommandMap(this);
     private final SimpleHelpMap helpMap = new SimpleHelpMap(this);
     private final StandardMessenger messenger = new StandardMessenger();
@@ -935,6 +945,48 @@ public final class CraftServer implements Server {
     @Override
     public CraftScheduler getScheduler() {
         return scheduler;
+    }
+
+    @Override
+    public @NotNull RegionScheduler getRegionScheduler() {
+        YouerRegionScheduler s = this.paperRegionScheduler;
+        if (s == null) {
+            synchronized (this) {
+                s = this.paperRegionScheduler;
+                if (s == null) {
+                    s = this.paperRegionScheduler = new YouerRegionScheduler(this);
+                }
+            }
+        }
+        return s;
+    }
+
+    @Override
+    public @NotNull GlobalRegionScheduler getGlobalRegionScheduler() {
+        YouerGlobalRegionScheduler s = this.paperGlobalRegionScheduler;
+        if (s == null) {
+            synchronized (this) {
+                s = this.paperGlobalRegionScheduler;
+                if (s == null) {
+                    s = this.paperGlobalRegionScheduler = new YouerGlobalRegionScheduler(this);
+                }
+            }
+        }
+        return s;
+    }
+
+    @Override
+    public @NotNull AsyncScheduler getAsyncScheduler() {
+        YouerAsyncScheduler s = this.paperAsyncScheduler;
+        if (s == null) {
+            synchronized (this) {
+                s = this.paperAsyncScheduler;
+                if (s == null) {
+                    s = this.paperAsyncScheduler = new YouerAsyncScheduler(this);
+                }
+            }
+        }
+        return s;
     }
 
     @Override

--- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockType.java
+++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockType.java
@@ -56,8 +56,17 @@ public class CraftBlockType<B extends BlockData> extends CraftRegistryItem<Block
     }
 
     private static boolean hasMethod(Class<?> clazz, Class<?>... params) {
+        final Method[] declaredMethods;
+        try {
+            declaredMethods = clazz.getDeclaredMethods();
+        } catch (NoClassDefFoundError | ExceptionInInitializerError ex) {
+            // Some transformed classes may reference client-only parameter types.
+            // Treat as non-interactable instead of crashing plugin enable/registry init.
+            return false;
+        }
+
         boolean hasMethod = false;
-        for (Method method : clazz.getDeclaredMethods()) {
+        for (Method method : declaredMethods) {
             if (Arrays.equals(method.getParameterTypes(), params)) {
                 Preconditions.checkArgument(!hasMethod, "More than one matching method for %s, args %s", clazz, Arrays.toString(params));
 

--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
@@ -1718,7 +1718,11 @@ public class CraftEventFactory {
         Preconditions.checkState(bukkitOldEffect != null || bukkitNewEffect != null, "Old and new potion effect are both null");
 
         EntityPotionEffectEvent event = new EntityPotionEffectEvent((org.bukkit.entity.LivingEntity) entity.getBukkitEntity(), bukkitOldEffect, bukkitNewEffect, cause, action, willOverride);
-        Bukkit.getPluginManager().callEvent(event);
+        // Some mods apply effects from chunk-generation worker threads. Firing a synchronous Bukkit
+        // event there would throw and crash generation; in that case, skip the callback and proceed.
+        if (Bukkit.isPrimaryThread()) {
+            Bukkit.getPluginManager().callEvent(event);
+        }
 
         return event;
     }

--- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
@@ -141,7 +141,8 @@ final class PluginClassLoader extends URLClassLoader {
 
                     if (provider != description
                             && !seenIllegalAccess.contains(provider.getName())
-                            && !((SimplePluginManager) loader.server.getPluginManager()).isTransitiveDepend(description, provider)) {
+                            && !((SimplePluginManager) loader.server.getPluginManager()).isTransitiveDepend(description, provider)
+                            && !isKnownOptionalPluginBridge(description.getName(), provider.getName(), name)) {
 
                         seenIllegalAccess.add(provider.getName());
                         if (plugin != null) {
@@ -242,5 +243,19 @@ final class PluginClassLoader extends URLClassLoader {
         this.pluginInit = javaPlugin;
 
         javaPlugin.init(loader, loader.server, description, dataFolder, file, this);
+    }
+
+    /**
+     * Vault discovers economy backends via reflection and may load Essentials' API classes without a declared
+     * {@code softdepend}; this is normal and safe for the economy bridge.
+     */
+    private static boolean isKnownOptionalPluginBridge(String consumerPlugin, String providerPlugin, String className) {
+        if (!"Vault".equals(consumerPlugin)) {
+            return false;
+        }
+        if (!className.startsWith("com.earth2me.essentials.api.")) {
+            return false;
+        }
+        return "Essentials".equals(providerPlugin);
     }
 }

--- a/src/main/resources/data/neoforge/loot_modifiers/global_loot_modifiers.json
+++ b/src/main/resources/data/neoforge/loot_modifiers/global_loot_modifiers.json
@@ -1,6 +1,0 @@
-{
-	"comment": "Entries will be loaded, parsed, and executed in order, first to last. Duplicate entries will override earlier entries and missing entries will be ignored while replace:true will clear the list first.",
-	"replace": false,
-	"entries": [
-	]
-}


### PR DESCRIPTION
Add a paper-thread-stub subproject (RegionScheduler, GlobalRegionScheduler, AsyncScheduler, ScheduledTask) and integrate it into the youer project to avoid JPMS split-package errors and restore compatibility with plugins that call Server.getRegionScheduler()/Paper Folia APIs (e.g. Vulcan, WorldGuard). Make all JavaCompile tasks depend on the setup task in NeoDevPlugin to fix a race with org.gradle.parallel=true so decompiled net.minecraft sources are synced before compilation. Add Commons Lang 2.6 to libraries to prevent NoClassDefFoundError for legacy plugins (ProtocolLib), remove an invalid NeoForge loot_modifiers JSON that caused parse errors, and un-finalize AnvilMenu#createResult to fix IncompatibleClassChangeError with Citizens. Other compatibility tweaks: add MixinMinecraftServer#z() delegating to isRunning(), correct DIM-1/DIM1 world mapping, make dynamic Bukkit enum injection opt-in and use -1 for generated entity type ids, add papercompat adapter classes, and include documentation (CHANGELOG.md, list.md, plugins.md) plus a VS Code launch config.