### PR TITLE
Fix entity water physics and hopper recipe choice crash

### DIFF
--- a/buildSrc/src/main/java/net/neoforged/neodev/NeoDevPlugin.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/NeoDevPlugin.java
@@ -459,7 +459,7 @@ public class NeoDevPlugin implements Plugin<Project> {
             if (project.getProperties().containsKey(installerDebugProperty) && Boolean.parseBoolean(project.getProperties().get(installerDebugProperty).toString())) {
                 task.from(universalJar.flatMap(AbstractArchiveTask::getArchiveFile), spec -> {
                     spec.into("data");
-                    spec.rename(_ -> String.format("neoforge-%s-universal.jar", neoForgeVersion.get()));
+                    spec.rename(name -> String.format("neoforge-%s-universal.jar", neoForgeVersion.get()));
                 });
             }
         });

--- a/patches/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/net/minecraft/world/entity/Entity.java.patch
@@ -2493,7 +2493,7 @@
          if (momentum.isFinite()) {
 -            this.setDeltaMovement(this.getDeltaMovement().add(momentum));
 +            synchronized (this.posLock) { // Paper - detailed watchdog information
-+                this.deltaMovement = deltaMovement;
++                this.deltaMovement = this.deltaMovement.add(momentum);
 +            } // Paper - detailed watchdog information
          }
      }

--- a/patches/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/net/minecraft/world/entity/LivingEntity.java.patch
@@ -1767,7 +1767,7 @@
 +     */
 +    @Deprecated
      protected void travelInFluid(Vec3 input) {
-+        travelInFluid(input, net.minecraft.world.level.material.Fluids.EMPTY.defaultFluidState());
++        travelInFluid(input, this.level().getFluidState(this.blockPosition()));
 +    }
 +
 +    private void travelInFluid(Vec3 input, FluidState fluidState) {

--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftRecipe.java
+++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftRecipe.java
@@ -73,6 +73,9 @@ public interface CraftRecipe extends Recipe {
             return new RecipeChoice.ExactChoice(choices);
         } else {
             final RegistryKeySet<ItemType> itemTypes = PaperRegistrySets.convertToApi(RegistryKey.ITEM, ingredient.values);
+            if (itemTypes.isEmpty()) {
+                return RecipeChoice.empty();
+            }
             return RecipeChoice.itemType(itemTypes);
         }
     }


### PR DESCRIPTION
### Description of Changes

This Pull Request resolves two critical bugs in Youer 26.2 (Paper/NeoForge hybrid core):

1. **Entity Fluid Physics Fix**:
   - **Issue**: Entities (items, mobs, TNT) were not being pushed by flowing water currents, and general knockbacks were broken.
   - **Cause**: A Paper watchdog thread safety patch introduced a merge error in `Entity#addDeltaMovement(Vec3)`, resulting in a no-op statement (`this.deltaMovement = deltaMovement;` instead of adding the momentum).
   - **Fix**: Restored the actual velocity addition operation: `this.deltaMovement = this.deltaMovement.add(momentum);` inside `Entity.java` and updated the corresponding patch `Entity.java.patch`.
   - **LivingEntity Patch**: Replaced a hardcoded `Fluids.EMPTY` placeholder with the real-time fluid state `this.level().getFluidState(this.blockPosition())` in `LivingEntity.java.patch`.

2. **Hopper Crafting/Placement Crash Fix**:
   - **Issue**: Crafting or placing a hopper caused the server to crash with `java.lang.IllegalArgumentException: ItemTypeChoice cannot be empty`.
   - **Cause**: Recipe translations returned an empty list of item types for certain tags, which failed Bukkit's strict choice requirements.
   - **Fix**: Modified `CraftRecipe.java` to safely return `RecipeChoice.empty()` when the translated set of item types is empty.
