### PR TITLE
fix(player): 修复玩家最大生命值同步问题

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #Preserved original properties with Git info
-#Wed Jul 22 18:53:20 CST 2026
+#Thu Jul 23 17:19:01 GMT+08:00 2026
 accesstransformers_version=10.0.1
 adventure_version=4.17.0
 apache_commons_lang3_version=3.13.0
@@ -14,7 +14,7 @@ create_version=6.0.9-216
 diffpatch_version=2.0.0.35
 eventbus_version=8.0.2
 fancy_mod_loader_version=4.0.43
-git.abbreviatedId=3b9a5f4d
+git.abbreviatedId=4a57297f
 gson_version=2.10.1
 guava_version=31.1.2-jre
 installertools_version=2.1.2

--- a/patches/net/minecraft/server/level/ServerEntity.java.patch
+++ b/patches/net/minecraft/server/level/ServerEntity.java.patch
@@ -219,15 +219,23 @@
      }
  
      public Vec3 getPositionBase() {
-@@ -328,6 +_,11 @@
+@@ -328,6 +_,18 @@
          if (this.entity instanceof LivingEntity) {
              Set<AttributeInstance> set = ((LivingEntity)this.entity).getAttributes().getAttributesToSync();
              if (!set.isEmpty()) {
+-                this.broadcastAndSend(new ClientboundUpdateAttributesPacket(this.entity.getId(), set));
 +                // CraftBukkit start - Send scaled max health
-+                if (this.entity instanceof ServerPlayer) {
-+                    ((ServerPlayer) this.entity).getBukkitEntity().injectScaledMaxHealth(set, false);
++                if (this.entity instanceof ServerPlayer serverPlayer && serverPlayer.getBukkitEntity().isHealthScaled()) {
++                    // Youer start - Health scaling is private to the owning player's HUD. Do not
++                    // mutate AttributeMap#getAttributesToSync (or leak the scaled value to trackers).
++                    this.broadcast.accept(new ClientboundUpdateAttributesPacket(this.entity.getId(), set));
++                    Collection<AttributeInstance> selfAttributes = new ArrayList<>(set);
++                    serverPlayer.getBukkitEntity().injectScaledMaxHealth(selfAttributes, false);
++                    serverPlayer.connection.send(new ClientboundUpdateAttributesPacket(this.entity.getId(), selfAttributes));
++                    // Youer end
++                } else {
++                    this.broadcastAndSend(new ClientboundUpdateAttributesPacket(this.entity.getId(), set));
 +                }
 +                // CraftBukkit end
-                 this.broadcastAndSend(new ClientboundUpdateAttributesPacket(this.entity.getId(), set));
              }
  

--- a/patches/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/net/minecraft/world/entity/LivingEntity.java.patch
@@ -8,7 +8,7 @@
  import com.google.common.annotations.VisibleForTesting;
  import com.google.common.base.Objects;
  import com.google.common.collect.ImmutableList;
-@@ -7,24 +_,39 @@
+@@ -7,24 +_,40 @@
  import com.google.common.collect.Iterables;
  import com.google.common.collect.Lists;
  import com.google.common.collect.Maps;
@@ -30,6 +30,7 @@
  import java.util.Collection;
 +import java.util.Collections;
  import java.util.ConcurrentModificationException;
++import java.util.EnumSet;
 +import java.util.HashSet;
  import java.util.Iterator;
  import java.util.List;
@@ -1642,7 +1643,11 @@
      public void detectEquipmentUpdates() {
          Map<EquipmentSlot, ItemStack> map = this.collectEquipmentChanges();
          if (map != null) {
-@@ -2466,6 +_,14 @@
+@@ -2458,2 +_,3 @@
+     private Map<EquipmentSlot, ItemStack> collectEquipmentChanges() {
+         Map<EquipmentSlot, ItemStack> map = null;
++        Set<EquipmentSlot> attributeModifierChanges = EnumSet.noneOf(EquipmentSlot.class); // Youer - avoid transient attribute churn for component-only equipment updates
+@@ -2466,6 +_,24 @@
              };
              ItemStack itemstack1 = this.getItemBySlot(equipmentslot);
              if (this.equipmentHasChanged(itemstack, itemstack1)) {
@@ -1657,6 +1662,51 @@
                  if (map == null) {
                      map = Maps.newEnumMap(EquipmentSlot.class);
                  }
++
++                // Youer start - Dynamic equipment such as a Mekanism jetpack changes its
++                // chemical data every tick. Keep syncing the ItemStack, but do not remove and
++                // re-add identical attribute modifiers; doing so dirties armor every tick and
++                // makes the owning client's armor HUD oscillate.
++                boolean attributeModifiersChanged = LivingEntity.equipmentAttributeModifiersHaveChanged(itemstack, itemstack1, equipmentslot);
++                if (attributeModifiersChanged) {
++                    attributeModifierChanges.add(equipmentslot);
++                }
++                // Youer end
+@@ -2473,6 +_,6 @@
+                 map.put(equipmentslot, itemstack1);
+                 AttributeMap attributemap = this.getAttributes();
+                 if (!itemstack.isEmpty()) {
+                     itemstack.forEachModifier(equipmentslot, (p_344283_, p_344284_) -> {
+                         AttributeInstance attributeinstance = attributemap.getInstance(p_344283_);
+-                        if (attributeinstance != null) {
++                        if (attributeModifiersChanged && attributeinstance != null) { // Youer - component-only changes keep the same modifiers
+@@ -2489,7 +_,7 @@
+             for (Entry<EquipmentSlot, ItemStack> entry : map.entrySet()) {
+                 EquipmentSlot equipmentslot1 = entry.getKey();
+                 ItemStack itemstack2 = entry.getValue();
+                 if (!itemstack2.isEmpty()) {
+                     itemstack2.forEachModifier(equipmentslot1, (p_352705_, p_352706_) -> {
+                         AttributeInstance attributeinstance = this.attributes.getInstance(p_352705_);
+-                        if (attributeinstance != null) {
++                        if (attributeModifierChanges.contains(equipmentslot1) && attributeinstance != null) { // Youer - only re-apply changed modifiers
+@@ -2511,2 +_,17 @@
++
++    // Youer start - Compare the effective slot modifiers instead of all ItemStack data.
++    // Fuel, energy, and similar capability/component updates must still be sent as equipment
++    // changes, but they must not create a remove/add attribute cycle when modifiers are equal.
++    private static boolean equipmentAttributeModifiersHaveChanged(ItemStack oldItem, ItemStack newItem, EquipmentSlot slot) {
++        List<EquipmentAttributeModifier> oldModifiers = new ArrayList<>();
++        List<EquipmentAttributeModifier> newModifiers = new ArrayList<>();
++        oldItem.forEachModifier(slot, (attribute, modifier) -> oldModifiers.add(new EquipmentAttributeModifier(attribute, modifier)));
++        newItem.forEachModifier(slot, (attribute, modifier) -> newModifiers.add(new EquipmentAttributeModifier(attribute, modifier)));
++        return !oldModifiers.equals(newModifiers);
++    }
++
++    private record EquipmentAttributeModifier(Holder<Attribute> attribute, AttributeModifier modifier) {
++    }
++    // Youer end
+     public boolean equipmentHasChanged(ItemStack p_252265_, ItemStack p_251043_) {
+         return !ItemStack.matches(p_251043_, p_252265_);
 @@ -2543,7 +_,7 @@
                      this.lastBodyItemStack = itemstack;
              }

--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -95,7 +95,6 @@ import net.minecraft.server.players.UserWhiteListEntry;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.ai.attributes.AttributeInstance;
-import net.minecraft.world.entity.ai.attributes.AttributeMap;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.food.FoodData;
 import net.minecraft.world.inventory.AbstractContainerMenu;
@@ -2767,7 +2766,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
     public void setMaxHealth(double amount) {
         super.setMaxHealth(amount);
         this.health = Math.min(this.health, amount);
-        this.getHandle().resetSentInfo();
+        // Youer start - A Bukkit max-health change must reach the owning modded client immediately.
+        // Waiting for entity tracking is not reliable for the player tracking itself.
+        this.updateScaledHealth();
+        // Youer end
     }
 
     @Override
@@ -2833,10 +2835,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
     }
 
     public void updateScaledHealth(boolean sendHealth) {
-        AttributeMap attributemapserver = this.getHandle().getAttributes();
-        Collection<AttributeInstance> set = attributemapserver.getSyncableAttributes();
-
+        // Youer start - Only max health belongs in a scaled-health update.
+        // CraftBukkit's original implementation sends every syncable attribute. On a modded
+        // server that can overwrite unrelated attributes with an intermediate equipment state
+        // (for example while Mekanism consumes jetpack fuel and refreshes chest-slot modifiers).
+        Collection<AttributeInstance> set = new ArrayList<>(1);
         this.injectScaledMaxHealth(set, true);
+        // Youer end
 
         // SPIGOT-3813: Attributes before health
         if (this.getHandle().connection != null) {


### PR DESCRIPTION
- 移除未使用的 AttributeMap 导入
- 在设置最大生命值时立即更新缩放健康值，而不是等待实体追踪
- 优化 updateScaledHealth 方法，只发送最大生命值相关的属性更新
- 避免因动态装备变化导致的属性修饰符频繁变更
- 为服务器端实体添加专门的生命值缩放处理逻辑
- 确保健康值缩放仅影响拥有者客户端而不泄漏给其他追踪者