### PR TITLE
Fix Shulker Box animation stuck open due to duplicate startOpen calls (clean branch)

### DIFF
--- a/patches/net/minecraft/world/level/block/entity/ShulkerBoxBlockEntity.java.patch
+++ b/patches/net/minecraft/world/level/block/entity/ShulkerBoxBlockEntity.java.patch
@@ -47,7 +47,17 @@
      public ShulkerBoxBlockEntity(@Nullable DyeColor color, BlockPos worldPosition, BlockState blockState) {
          super(BlockEntityTypes.SHULKER_BOX, worldPosition, blockState);
          this.color = color;
-@@ -171,6 +_,7 @@
+@@ -166,11 +_,17 @@
+     @Override
+     public void startOpen(ContainerUser containerUser) {
+         if (!this.remove && !containerUser.getLivingEntity().isSpectator()) {
++            if (containerUser.getLivingEntity() instanceof net.minecraft.world.entity.player.Player player) {
++                if (this.transaction.contains(player.getBukkitEntity())) {
++                    return;
++                }
++            }
+             if (this.openCount < 0) {
+                 this.openCount = 0;
              }
  
              this.openCount++;


### PR DESCRIPTION
### Description
This pull request addresses a bug where Shulker Boxes remain stuck in their open animation state after a player closes their inventory.

### Cause
The issue is caused by duplicate `container.startOpen()` execution paths on hybrid servers:
1. The first call occurs within the CraftBukkit inventory open event pipeline (`CraftEventFactory.callInventoryOpenEventWithTitle`).
2. The second call occurs during NeoForge's menu initialization (`ServerPlayer#initMenu`).

This causes the server-side `openCount` to increment twice (from 0 to 2) while only decrementing once on container close (from 2 to 1). Because `openCount` never returns to 0, the server does not send the block event to transition the container to the closed state.

### Solution
Added a validation check in `ShulkerBoxBlockEntity#startOpen`. If the player is already registered in the Bukkit transaction viewer list, the second increment call is skipped. This keeps the count synchronized and allows the Shulker Box lid to close correctly.
